### PR TITLE
fix pip command url typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ not an official project of Comet ML. We welcome contributions!
 ## Installation
 
 ```
-pip install git+https://github.com:comet-ml/comet-sdk-extensions.git#egg=cometx
+pip install git+https://github.com/comet-ml/comet-sdk-extensions.git#egg=cometx
 ```
 
 ## Usage


### PR DESCRIPTION
running: 
```
pip install git+https://github.com:comet-ml/comet-sdk-extensions.git#egg=cometx
```
got error:
```
  fatal: unable to access 'https://github.com:comet-ml/comet-sdk-extensions.git/': URL using bad/illegal format or missing URL
```