### PR TITLE
feat(admin): chargeback-only growth-report (org overview, users, leaderboards, personal-vs-service)

### DIFF
--- a/README-ADMIN.md
+++ b/README-ADMIN.md
@@ -148,6 +148,11 @@ If no workspace is given, all workspaces visible to the current API key are used
 - **`--platforms PLATFORMS`**: Comma-separated platforms to include (default: `em,opik,mpm`).
 - **`--output PATH`**: Output HTML file path (default: `growth_report.html`).
 - **`--limit N`**: Limit the number of workspaces processed — useful for a fast smoke-test run.
+- **`--active-window WINDOW`**: Activity window for the users/people layer, e.g. `30d`/`60d` (default: `60d`). A user counts as *active* when their overall last-used timestamp falls within this window.
+- **`--leaderboard-top-n N`**: Top/bottom N size for the leaderboards section (default: `5`).
+- **`--no-users`**: Skip the chargeback-based users/people layer entirely (People, Leaderboards, and Personal-vs-Service sections). Use this when the chargeback report is unavailable or not needed.
+- **`--exclude-personal`**: Drop workspaces whose name matches `--personal-pattern` before collection (default: off; has no effect without `--personal-pattern`).
+- **`--personal-pattern REGEX`**: Regex used with `--exclude-personal` to identify personal-workspace names to drop, e.g. `'^user-'` (default: none).
 - **`--no-open`**: Don't automatically open the generated HTML file after generation.
 
 ### The two time concepts
@@ -173,6 +178,14 @@ cometx admin growth-report --platforms em,opik --window 30d my-workspace another
 
 # Fast smoke-test run against a single workspace, don't auto-open
 cometx admin growth-report --limit 1 --no-open --output growth.html my-workspace
+
+# People layer with a 30-day activity window and top/bottom-10 leaderboards,
+# excluding personal workspaces named like "user-..."
+cometx admin growth-report --active-window 30d --leaderboard-top-n 10 \
+  --exclude-personal --personal-pattern '^user-' my-workspace
+
+# Growth/adoption only, skipping the chargeback-based people layer
+cometx admin growth-report --no-users my-workspace
 ```
 
 ### Output
@@ -181,7 +194,13 @@ The growth report generates a single self-contained HTML file containing:
 
 - A **unified section** ("Use cases across all platforms") with department/use-case KPIs, a stacked created-per-period chart broken down by kind (Opik/EM/MPM), a use-cases-by-department chart, and a breakdown table.
 - Per-product **growth** sections (Opik / EM / MPM) with Total / New / % Growth KPIs, a new-use-cases bar chart, a cumulative area chart (both carrying the analysis window as a shaded band), and a breakdown table.
-- Per-product **adoption** sections with secondary usage metrics — Opik span counts, EM experiment counts, MPM prediction volume — each broken down by project.
+- Per-product **adoption** sections with secondary usage metrics — Opik span counts (and trace counts), EM experiment counts, MPM prediction volume — each broken down by project.
+
+When the chargeback report is available (and `--no-users` is not passed), three additional people/usage sections are included:
+
+- A **Users / People** section with Total / Active (`--active-window`) / Adoption % KPIs and active-vs-total and per-capability adoption line charts over time.
+- A **Leaderboards** section ranking workspaces and users by each available platform metric (EM experiments, Opik spans + traces, MPM predictions), as top-N and active-aware bottom-N. Platforms or metrics with no data are omitted.
+- A **Personal vs Service accounts** section splitting experiments / data / spans between personal and service accounts. Service accounts are identified from the admin service-accounts API when available, falling back to a labeled regex heuristic; the source is shown in the panel hint.
 
 The breakdown tables follow one rule throughout: when more than one workspace is included,
 tables break down **by workspace/department**; when only a single workspace is included,
@@ -195,3 +214,4 @@ would be uninformative).
 - **The EM model-registry engagement panel is a snapshot**, not an over-time series ("Registered models" / "Model versions" per workspace) — it is kept in its own labeled panel and is **never** combined with MPM's monitored-model counts, even though both are "model" concepts.
 - **MPM requires provisioning.** If the account/workspace has no MPM model-monitoring provisioned, the MPM collector degrades gracefully — an empty MPM section and `collectors.mpm: false` in the underlying report data — rather than failing the whole report.
 - Opik and MPM collection require their optional SDKs (`opik`, `comet_mpm`). Install them with `pip install 'cometx[all]'` if not already available; any platform whose SDK can't be imported is silently dropped from `--platforms` (a note is printed to the console) so the report still succeeds with the remaining platforms.
+- **The people/usage layer degrades independently.** The People, Leaderboards, and Personal-vs-Service sections are derived from the admin chargeback report (and the service-accounts endpoint). If either is unavailable or returns an unexpected shape, a warning is printed and only those sections are dropped — the rest of the report still generates. Some fields (per-user span counts, per-capability last-used timestamps) are optional in the chargeback payload; panels that depend on a missing field are omitted rather than faked.

--- a/README-ADMIN.md
+++ b/README-ADMIN.md
@@ -125,10 +125,16 @@ When using the `--app` flag, an interactive web interface is launched where you 
 
 ## growth-report
 
-Generate a cross-platform use-case growth & adoption report — Opik projects, EM projects,
-and MPM monitored models — as a single self-contained HTML page. This is distinct from
-`usage-report` (an experiment-count PDF): `growth-report` tracks *how many use cases exist
-and how fast they're being created*, per workspace/department, across all three products.
+Generate an organization growth & adoption report as a single self-contained
+HTML page, built entirely from the **admin chargeback report**. Distinct from
+`usage-report` (an experiment-count PDF): `growth-report` gives an org-wide view
+of workspaces, users, and platform adoption, broken down by workspace/department.
+
+**Requires an admin API key.** The report is derived entirely from the admin
+chargeback endpoint; with a non-admin key the command prints an error and exits
+non-zero — there is no fallback. (An earlier SDK/platform-direct methodology that
+collected per-workspace Opik/EM/MPM data has been retired from this command and
+is preserved on the local `growth-report-sdk-full` git branch.)
 
 ### Basic Usage
 
@@ -138,80 +144,64 @@ cometx admin growth-report my-workspace
 cometx admin growth-report my-workspace another-workspace
 ```
 
-If no workspace is given, all workspaces visible to the current API key are used.
+Chargeback data is org-wide by default. If one or more workspaces are given, the
+report is scoped to just those workspaces.
 
 ### Options
 
-- **`WORKSPACE ...`**: Zero or more workspaces to include. If omitted, resolved via `get_workspaces()`.
-- **`--units {month,week,day,hour}`**: Chart bucket granularity (default: `month`). Charts always render **all-time** history at this granularity — this is a separate concept from `--window`, below.
-- **`--window WINDOW`**: Relative analysis window for the KPI numbers, e.g. `7d`, `14d`, `30d`, `90d`, `2w`, `6m`, `1y` (default: `7d`). Format is `\d+[dwmy]`: `d`=days, `w`=weeks (×7 days), `m`=months (approximated as 30 days), `y`=years (approximated as 365 days). The month/year approximation is intentional — the window is only used to compute an "installed base before window" cutoff, not calendar-exact arithmetic.
-- **`--platforms PLATFORMS`**: Comma-separated platforms to include (default: `em,opik,mpm`).
+- **`WORKSPACE ...`**: Zero or more workspaces to scope the report to. If omitted, the report is org-wide.
+- **`--units {month,week,day,hour}`**: Chart bucket granularity (default: `month`). Charts render all-time history at this granularity — a separate concept from `--window`.
+- **`--window WINDOW`**: Relative analysis window for the growth KPIs, e.g. `7d`, `14d`, `30d`, `90d`, `2w`, `6m`, `1y` (default: `7d`). Format `\d+[dwmy]`: `d`=days, `w`=weeks (×7 days), `m`=months (≈30 days), `y`=years (≈365 days).
 - **`--output PATH`**: Output HTML file path (default: `growth_report.html`).
-- **`--limit N`**: Limit the number of workspaces processed — useful for a fast smoke-test run.
-- **`--active-window WINDOW`**: Activity window for the users/people layer, e.g. `30d`/`60d` (default: `60d`). A user counts as *active* when their overall last-used timestamp falls within this window.
+- **`--active-window WINDOW`**: Activity window for the users layer, e.g. `30d`/`60d` (default: `60d`). A user counts as *active* when their last-used timestamp falls within this window.
 - **`--leaderboard-top-n N`**: Top/bottom N size for the leaderboards section (default: `5`).
-- **`--no-users`**: Skip the chargeback-based users/people layer entirely (People, Leaderboards, and Personal-vs-Service sections). Use this when the chargeback report is unavailable or not needed.
-- **`--exclude-personal`**: Drop workspaces whose name matches `--personal-pattern` before collection (default: off; has no effect without `--personal-pattern`).
+- **`--exclude-personal`**: Drop workspaces whose name matches `--personal-pattern` from the chargeback data (default: off; has no effect without `--personal-pattern`).
 - **`--personal-pattern REGEX`**: Regex used with `--exclude-personal` to identify personal-workspace names to drop, e.g. `'^user-'` (default: none).
 - **`--no-open`**: Don't automatically open the generated HTML file after generation.
 
 ### The two time concepts
 
 - **`--units`** is the *chart granularity*: every chart shows the complete all-time history bucketed at this resolution.
-- **`--window`** is the *KPI analysis window*: Total/New/% Growth numbers compare "in the last `--window`" against "before the window." On the charts, the window is drawn as a shaded band overlaid on the all-time series, rather than filtering the data.
+- **`--window`** is the *KPI analysis window*: the "New in {window} (% of base)" growth KPIs compare accounts/workspaces created in the last `--window` against those that existed before it.
 
 ### Growth rates
 
-Growth and adoption rates are computed directly from use-case **creation timestamps**:
-`pct_growth = new_in_window / count_before_window`, where `count_before_window` is the
-number of use cases created before `window.start` and `new_in_window` is the number
-created inside `[window.start, window.end]`.
+The growth KPIs are computed from chargeback `createdAt` timestamps:
+`new_in_window / count_before_window × 100`, where `count_before_window` is the
+count that existed before `window.start` and `new_in_window` is the count created
+inside `[window.start, window.end]`. Workspace creation is proxied from each
+workspace's earliest member `createdAt`.
 
 ### Examples
 
 ```shell
-# Full cross-platform report for all workspaces, default 7-day window
+# Org-wide report, default 7-day window
 cometx admin growth-report
 
-# Just Opik + EM, 30-day window, for two workspaces
-cometx admin growth-report --platforms em,opik --window 30d my-workspace another-workspace
+# 30-day window, scoped to two workspaces
+cometx admin growth-report --window 30d my-workspace another-workspace
 
-# Fast smoke-test run against a single workspace, don't auto-open
-cometx admin growth-report --limit 1 --no-open --output growth.html my-workspace
+# Write to a file without auto-opening
+cometx admin growth-report --no-open --output growth.html
 
-# People layer with a 30-day activity window and top/bottom-10 leaderboards,
-# excluding personal workspaces named like "user-..."
+# 30-day activity window and top/bottom-10 leaderboards, excluding personal
+# workspaces named like "user-..."
 cometx admin growth-report --active-window 30d --leaderboard-top-n 10 \
-  --exclude-personal --personal-pattern '^user-' my-workspace
-
-# Growth/adoption only, skipping the chargeback-based people layer
-cometx admin growth-report --no-users my-workspace
+  --exclude-personal --personal-pattern '^user-'
 ```
 
 ### Output
 
-The growth report generates a single self-contained HTML file containing:
+The report generates a single self-contained HTML file containing:
 
-- A **unified section** ("Use cases across all platforms") with department/use-case KPIs, a stacked created-per-period chart broken down by kind (Opik/EM/MPM), a use-cases-by-department chart, and a breakdown table.
-- Per-product **growth** sections (Opik / EM / MPM) with Total / New / % Growth KPIs, a new-use-cases bar chart, a cumulative area chart (both carrying the analysis window as a shaded band), and a breakdown table.
-- Per-product **adoption** sections with secondary usage metrics — Opik span counts (and trace counts), EM experiment counts, MPM prediction volume — each broken down by project.
-
-When the chargeback report is available (and `--no-users` is not passed), three additional people/usage sections are included:
-
-- A **Users / People** section with Total / Active (`--active-window`) / Adoption % KPIs and active-vs-total and per-capability adoption line charts over time.
-- A **Leaderboards** section ranking workspaces and users by each available platform metric (EM experiments, Opik spans + traces, MPM predictions), as top-N and active-aware bottom-N. Platforms or metrics with no data are omitted.
+- An **Organization overview (chargeback)** section with org-wide KPIs (Total workspaces, Total EM projects, New in {window} (% of base), Active workspaces %), a workspace platform-mix chart (EM / Opik / both / neither), workspace total-vs-active and added-vs-deleted charts, and a by-workspace table.
+- A **Users** section with Total / Active (`--active-window`) / Active % / New in {window} KPIs, plus active-vs-total, adoption-rate, per-capability, and user-churn charts.
+- A **Leaderboards** section ranking workspaces (by experiments and EM projects, exact from chargeback) and users (by Opik spans and EM activity), as top-N and active-aware bottom-N. Metrics with no data are omitted.
 - A **Personal vs Service accounts** section splitting experiments / data / spans between personal and service accounts. Service accounts are identified from the admin service-accounts API when available, falling back to a labeled regex heuristic; the source is shown in the panel hint.
-
-The breakdown tables follow one rule throughout: when more than one workspace is included,
-tables break down **by workspace/department**; when only a single workspace is included,
-tables break down **by individual use case** instead (a by-workspace table with one row
-would be uninformative).
 
 ### Caveats
 
-- **EM "created" is a proxy.** The Comet API has no true EM project-creation timestamp, so an EM project's creation time is approximated as the earliest experiment start time in that project, falling back to the project's `lastUpdated` time if it has no experiments.
-- **Workspace/department "created" is also a proxy** — the earliest use-case creation timestamp seen in that workspace, across all platforms.
-- **The EM model-registry engagement panel is a snapshot**, not an over-time series ("Registered models" / "Model versions" per workspace) — it is kept in its own labeled panel and is **never** combined with MPM's monitored-model counts, even though both are "model" concepts.
-- **MPM requires provisioning.** If the account/workspace has no MPM model-monitoring provisioned, the MPM collector degrades gracefully — an empty MPM section and `collectors.mpm: false` in the underlying report data — rather than failing the whole report.
-- Opik and MPM collection require their optional SDKs (`opik`, `comet_mpm`). Install them with `pip install 'cometx[all]'` if not already available; any platform whose SDK can't be imported is silently dropped from `--platforms` (a note is printed to the console) so the report still succeeds with the remaining platforms.
-- **The people/usage layer degrades independently.** The People, Leaderboards, and Personal-vs-Service sections are derived from the admin chargeback report (and the service-accounts endpoint). If either is unavailable or returns an unexpected shape, a warning is printed and only those sections are dropped — the rest of the report still generates. Some fields (per-user span counts, per-capability last-used timestamps) are optional in the chargeback payload; panels that depend on a missing field are omitted rather than faked.
+- **Chargeback is required.** The whole report is derived from the admin chargeback report; without admin access the command errors out (non-zero exit).
+- **Workspace "created" is a proxy** — the earliest member `createdAt` in that workspace, since chargeback has no workspace-creation timestamp. The added-vs-deleted "deleted" series is also a best-effort proxy (all members removed) and typically reads ~0.
+- **"Total projects" counts EM projects only** — chargeback's per-workspace `projects[]` covers Experiment Management. Opik projects and MPM aren't represented there (Opik appears only as a per-user span count; MPM is absent), so the platform mix uses an Opik per-user proxy and excludes MPM.
+- **The people layer degrades independently.** If the chargeback payload parses but a section's inputs are missing, a warning is printed and only that section is dropped — the rest of the report still generates.

--- a/README-ADMIN.md
+++ b/README-ADMIN.md
@@ -132,9 +132,7 @@ of workspaces, users, and platform adoption, broken down by workspace/department
 
 **Requires an admin API key.** The report is derived entirely from the admin
 chargeback endpoint; with a non-admin key the command prints an error and exits
-non-zero — there is no fallback. (An earlier SDK/platform-direct methodology that
-collected per-workspace Opik/EM/MPM data has been retired from this command and
-is preserved on the local `growth-report-sdk-full` git branch.)
+non-zero — there is no fallback.
 
 ### Basic Usage
 

--- a/README.md
+++ b/README.md
@@ -587,9 +587,7 @@ workspaces, users, and platform adoption, per workspace/department.
 
 **Requires an admin API key** — the report is derived entirely from the admin
 chargeback endpoint, and with a non-admin key the command errors out (non-zero
-exit). The earlier SDK/platform-direct methodology (per-workspace Opik/EM/MPM
-collection) has been retired from this command and is preserved on the local
-`growth-report-sdk-full` git branch.
+exit).
 
 ```
 cometx admin growth-report [WORKSPACE ...]

--- a/README.md
+++ b/README.md
@@ -598,6 +598,11 @@ cometx admin growth-report [WORKSPACE ...]
 * `--platforms PLATFORMS` - Comma-separated list of platforms to include (default: `em,opik,mpm`). Any of `em`, `opik`, `mpm`.
 * `--output PATH` - Output HTML file path (default: `growth_report.html`).
 * `--limit N` - Limit the number of workspaces processed (useful for a fast smoke-test run).
+* `--active-window WINDOW` - Activity window for the users/people layer, e.g. `30d`/`60d` (default: `60d`). A user is *active* when their overall last-used timestamp falls within this window.
+* `--leaderboard-top-n N` - Top/bottom N size for the leaderboards section (default: `5`).
+* `--no-users` - Skip the chargeback-based users/people layer (People, Leaderboards, Personal-vs-Service sections).
+* `--exclude-personal` - Drop workspaces whose name matches `--personal-pattern` before collection (default: off; no effect without `--personal-pattern`).
+* `--personal-pattern REGEX` - Regex used with `--exclude-personal` to identify personal-workspace names to drop, e.g. `'^user-'` (default: none).
 * `--no-open` - Don't automatically open the generated HTML file after generation.
 
 **Two time concepts:**
@@ -607,6 +612,14 @@ cometx admin growth-report [WORKSPACE ...]
 **Growth rates:** growth/adoption rates are computed from use-case **creation timestamps**
 (`--window` boundary vs. each event's `created` time), not from a separate "installed base"
 snapshot, so `pct_growth` is always `new_in_window / count_before_window`.
+
+**People / usage layer:** unless `--no-users` is passed, the report also derives a chargeback-based
+people layer — a **Users / People** section (Total / Active / Adoption % plus over-time line charts),
+a **Leaderboards** section (top-N and active-aware bottom-N workspaces and users by EM experiments,
+Opik spans + traces, and MPM predictions), and a **Personal vs Service accounts** split (service
+accounts from the admin API, with a labeled regex fallback). This layer degrades independently: if
+the chargeback or service-accounts data is unavailable or malformed, a warning is printed and only
+those sections are dropped.
 
 **Caveats:**
 * **EM "created" is a proxy** — the Comet API has no true EM project-creation timestamp, so EM project creation is approximated as the earliest experiment start time in that project (falling back to the project's `lastUpdated` time if no experiments exist).
@@ -625,6 +638,14 @@ cometx admin growth-report --platforms em,opik --window 30d my-workspace another
 
 # Fast smoke-test run against a single workspace, don't auto-open
 cometx admin growth-report --limit 1 --no-open --output growth.html my-workspace
+
+# People layer with a 30-day activity window and top/bottom-10 leaderboards,
+# excluding personal workspaces named like "user-..."
+cometx admin growth-report --active-window 30d --leaderboard-top-n 10 \
+  --exclude-personal --personal-pattern '^user-' my-workspace
+
+# Growth/adoption only, skipping the chargeback-based people layer
+cometx admin growth-report --no-users my-workspace
 ```
 
 #### gpu-report

--- a/README.md
+++ b/README.md
@@ -580,72 +580,72 @@ cometx admin usage-report --app
 
 #### growth-report
 
-Generate a cross-platform use-case growth & adoption report (Opik projects, EM projects,
-MPM monitored models) as a single self-contained HTML page. Distinct from `usage-report`
-(experiment-count PDF): `growth-report` tracks *how many use cases exist and how fast
-they're being created*, per workspace/department, across all three products.
+Generate an organization growth & adoption report as a single self-contained HTML
+page, built entirely from the **admin chargeback report**. Distinct from
+`usage-report` (experiment-count PDF): `growth-report` gives an org-wide view of
+workspaces, users, and platform adoption, per workspace/department.
+
+**Requires an admin API key** — the report is derived entirely from the admin
+chargeback endpoint, and with a non-admin key the command errors out (non-zero
+exit). The earlier SDK/platform-direct methodology (per-workspace Opik/EM/MPM
+collection) has been retired from this command and is preserved on the local
+`growth-report-sdk-full` git branch.
 
 ```
 cometx admin growth-report [WORKSPACE ...]
 ```
 
 **Arguments:**
-* `WORKSPACE` (optional, zero or more) - Workspaces to include. If omitted, all workspaces visible to the current API key are used (via `get_workspaces()`).
+* `WORKSPACE` (optional, zero or more) - Workspaces to scope the report to. If omitted, the report is org-wide.
 
 **Options:**
-* `--units {month,week,day,hour}` - Chart bucket granularity (default: month). Charts always render **all-time** history at this granularity; this is unrelated to `--window` below.
-* `--window WINDOW` - Relative analysis window for the KPIs, e.g. `7d`, `14d`, `30d`, `90d`, `2w`, `6m`, `1y` (default: `7d`). `d`=days, `w`=weeks (×7d), `m`=months (approximated as 30 days), `y`=years (approximated as 365 days) — the approximation is intentional, since the window only needs an "installed base before window" cutoff, not calendar-exact arithmetic.
-* `--platforms PLATFORMS` - Comma-separated list of platforms to include (default: `em,opik,mpm`). Any of `em`, `opik`, `mpm`.
+* `--units {month,week,day,hour}` - Chart bucket granularity (default: month). Charts render all-time history at this granularity; unrelated to `--window` below.
+* `--window WINDOW` - Relative analysis window for the growth KPIs, e.g. `7d`, `14d`, `30d`, `90d`, `2w`, `6m`, `1y` (default: `7d`). `d`=days, `w`=weeks (×7d), `m`=months (≈30 days), `y`=years (≈365 days).
 * `--output PATH` - Output HTML file path (default: `growth_report.html`).
-* `--limit N` - Limit the number of workspaces processed (useful for a fast smoke-test run).
-* `--active-window WINDOW` - Activity window for the users/people layer, e.g. `30d`/`60d` (default: `60d`). A user is *active* when their overall last-used timestamp falls within this window.
+* `--active-window WINDOW` - Activity window for the users layer, e.g. `30d`/`60d` (default: `60d`). A user is *active* when their last-used timestamp falls within this window.
 * `--leaderboard-top-n N` - Top/bottom N size for the leaderboards section (default: `5`).
-* `--no-users` - Skip the chargeback-based users/people layer (People, Leaderboards, Personal-vs-Service sections).
-* `--exclude-personal` - Drop workspaces whose name matches `--personal-pattern` before collection (default: off; no effect without `--personal-pattern`).
+* `--exclude-personal` - Drop workspaces whose name matches `--personal-pattern` from the chargeback data (default: off; no effect without `--personal-pattern`).
 * `--personal-pattern REGEX` - Regex used with `--exclude-personal` to identify personal-workspace names to drop, e.g. `'^user-'` (default: none).
 * `--no-open` - Don't automatically open the generated HTML file after generation.
 
 **Two time concepts:**
 * `--units` controls chart *granularity* — every chart shows the full all-time history bucketed at this resolution.
-* `--window` controls the *analysis window* used for the KPI numbers (Total / New / % growth) — it's drawn as a shaded band on top of the all-time charts rather than filtering them out.
+* `--window` controls the *analysis window* for the "New in {window} (% of base)" growth KPIs — accounts/workspaces created in the last `--window` vs. those that existed before it.
 
-**Growth rates:** growth/adoption rates are computed from use-case **creation timestamps**
-(`--window` boundary vs. each event's `created` time), not from a separate "installed base"
-snapshot, so `pct_growth` is always `new_in_window / count_before_window`.
+**Growth rates:** the growth KPIs are computed from chargeback `createdAt`
+timestamps as `new_in_window / count_before_window × 100`. Workspace creation is
+proxied from each workspace's earliest member `createdAt`.
 
-**People / usage layer:** unless `--no-users` is passed, the report also derives a chargeback-based
-people layer — a **Users / People** section (Total / Active / Adoption % plus over-time line charts),
-a **Leaderboards** section (top-N and active-aware bottom-N workspaces and users by EM experiments,
-Opik spans + traces, and MPM predictions), and a **Personal vs Service accounts** split (service
-accounts from the admin API, with a labeled regex fallback). This layer degrades independently: if
-the chargeback or service-accounts data is unavailable or malformed, a warning is printed and only
-those sections are dropped.
+**Report sections:** an **Organization overview (chargeback)** section (org-wide
+KPIs, workspace platform mix, total-vs-active and added-vs-deleted charts, and a
+by-workspace table), a **Users** section (Total / Active / Active % / New-in-window
+KPIs plus over-time charts), a **Leaderboards** section (top-N and active-aware
+bottom-N workspaces by experiments/projects and users by Opik spans / EM activity,
+exact from chargeback), and a **Personal vs Service accounts** split (service
+accounts from the admin API, with a labeled regex fallback). Each people section
+degrades independently: if its inputs are missing, a warning is printed and only
+that section is dropped.
 
 **Caveats:**
-* **EM "created" is a proxy** — the Comet API has no true EM project-creation timestamp, so EM project creation is approximated as the earliest experiment start time in that project (falling back to the project's `lastUpdated` time if no experiments exist).
-* **Workspace/department "created" is also a proxy** — it's the earliest use-case creation timestamp seen in that workspace, across all platforms.
-* **MPM requires provisioning** — if the account/workspace has no MPM model-monitoring provisioned, the MPM collector degrades gracefully (an empty MPM section, `collectors.mpm: false`) instead of failing the whole report.
-
-Opik and MPM collection require their optional SDKs; install them with `pip install 'cometx[all]'` if they aren't already available. Platforms whose SDK can't be imported are silently dropped from `--platforms` (a note is printed) so the report still succeeds with the remaining platforms.
+* **Chargeback is required** — the whole report is derived from the admin chargeback report; without admin access the command errors out.
+* **Workspace "created" is a proxy** — the earliest member `createdAt`, since chargeback has no workspace-creation timestamp. The added-vs-deleted "deleted" series is also a best-effort proxy (all members removed) and typically reads ~0.
+* **"Total projects" counts EM projects only** — chargeback's per-workspace `projects[]` covers Experiment Management; Opik projects and MPM aren't represented (Opik appears only as a per-user span count; MPM is absent).
 
 **Examples:**
 ```
-# Full cross-platform report for all workspaces, default 7-day window
+# Org-wide report, default 7-day window
 cometx admin growth-report
 
-# Just Opik + EM, 30-day window, monthly chart granularity, for two workspaces
-cometx admin growth-report --platforms em,opik --window 30d my-workspace another-workspace
+# 30-day window, scoped to two workspaces
+cometx admin growth-report --window 30d my-workspace another-workspace
 
-# Fast smoke-test run against a single workspace, don't auto-open
-cometx admin growth-report --limit 1 --no-open --output growth.html my-workspace
+# Write to a file without auto-opening
+cometx admin growth-report --no-open --output growth.html
 
-# People layer with a 30-day activity window and top/bottom-10 leaderboards,
-# excluding personal workspaces named like "user-..."
+# 30-day activity window and top/bottom-10 leaderboards, excluding personal
+# workspaces named like "user-..."
 cometx admin growth-report --active-window 30d --leaderboard-top-n 10 \
-  --exclude-personal --personal-pattern '^user-' my-workspace
-
-# Growth/adoption only, skipping the chargeback-based people layer
-cometx admin growth-report --no-users my-workspace
+  --exclude-personal --personal-pattern '^user-'
 ```
 
 #### gpu-report

--- a/cometx/_version.py
+++ b/cometx/_version.py
@@ -12,5 +12,5 @@
 #  the express permission of Comet ML Inc.
 # *******************************************************
 
-version_info = (3, 6, 8)
+version_info = (3, 6, 9)
 __version__ = ".".join(map(str, version_info))

--- a/cometx/cli/admin.py
+++ b/cometx/cli/admin.py
@@ -548,6 +548,23 @@ Examples:
         help="Skip the chargeback-based users/people layer",
     )
     growth_parser.add_argument(
+        "--exclude-personal",
+        action="store_true",
+        default=False,
+        help=(
+            "Drop workspaces whose name matches --personal-pattern before "
+            "collection (default: off; has no effect without --personal-pattern)"
+        ),
+    )
+    growth_parser.add_argument(
+        "--personal-pattern",
+        default=None,
+        help=(
+            "Regex used with --exclude-personal to identify personal-workspace "
+            "names to drop, e.g. '^user-' (default: none)"
+        ),
+    )
+    growth_parser.add_argument(
         "--no-open",
         help="Don't automatically open the generated HTML file",
         default=False,
@@ -831,6 +848,8 @@ def admin(parsed_args, remaining=None):
                     active_window=parsed_args.active_window,
                     include_users=parsed_args.include_users,
                     leaderboard_top_n=parsed_args.leaderboard_top_n,
+                    exclude_personal=parsed_args.exclude_personal,
+                    personal_pattern=parsed_args.personal_pattern,
                 )
             except Exception as e:
                 print("ERROR: " + str(e))

--- a/cometx/cli/admin.py
+++ b/cometx/cli/admin.py
@@ -149,9 +149,10 @@ import argparse
 import json
 import os
 import sys
-from urllib.parse import urlparse
 
 from comet_ml import API
+
+from cometx.utils import fetch_chargeback_report
 
 from .admin_gpu_report import main as gpu_report_main
 from .admin_growth_report import generate_growth_report
@@ -542,39 +543,17 @@ def admin(parsed_args, remaining=None):
         api = API()
 
         if parsed_args.ACTION == "chargeback-report":
-            if parsed_args.host is not None:
-                admin_url = parsed_args.host
-            else:
-                url = api.config["comet.url_override"]
-                result = urlparse(url)
-                admin_url = "%s://%s" % (
-                    result.scheme,
-                    result.netloc,
-                )
-
-            while admin_url.endswith("/"):
-                admin_url = admin_url[:-1]
-
-            admin_url += "/api/admin/chargeback/report"
-
-            print("Attempting to get chargeback report from %s..." % admin_url)
+            print("Attempting to get chargeback report...")
+            report = fetch_chargeback_report(
+                api, host=parsed_args.host, report_month=parsed_args.YEAR_MONTH
+            )
             if parsed_args.YEAR_MONTH:
-                response = api._client.get(
-                    admin_url + ("?reportMonth=%s" % parsed_args.YEAR_MONTH),
-                    headers={"Authorization": api.api_key},
-                    params={},
-                )
                 filename = "comet-chargeback-report-%s.json" % parsed_args.YEAR_MONTH
             else:
-                response = api._client.get(
-                    admin_url,
-                    headers={"Authorization": api.api_key},
-                    params={},
-                )
                 filename = "comet-chargeback-report.json"
             print("Attempting to save chargeback report...")
             with open(filename, "w") as fp:
-                fp.write(json.dumps(response.json()))
+                fp.write(json.dumps(report))
             print("Chargeback report is saved in %r" % filename)
         elif parsed_args.ACTION == "usage-report":
             if parsed_args.app:

--- a/cometx/cli/admin.py
+++ b/cometx/cli/admin.py
@@ -530,6 +530,24 @@ Examples:
         default=None,
     )
     growth_parser.add_argument(
+        "--active-window",
+        default="60d",
+        help="Activity window for the users/people layer, e.g. 30d/60d (default: 60d)",
+    )
+    growth_parser.add_argument(
+        "--leaderboard-top-n",
+        type=int,
+        default=5,
+        help="Top/bottom N size for leaderboards (default: 5)",
+    )
+    growth_parser.add_argument(
+        "--no-users",
+        dest="include_users",
+        action="store_false",
+        default=True,
+        help="Skip the chargeback-based users/people layer",
+    )
+    growth_parser.add_argument(
         "--no-open",
         help="Don't automatically open the generated HTML file",
         default=False,
@@ -810,6 +828,9 @@ def admin(parsed_args, remaining=None):
                     output=parsed_args.output,
                     no_open=parsed_args.no_open,
                     limit=parsed_args.limit,
+                    active_window=parsed_args.active_window,
+                    include_users=parsed_args.include_users,
+                    leaderboard_top_n=parsed_args.leaderboard_top_n,
                 )
             except Exception as e:
                 print("ERROR: " + str(e))

--- a/cometx/cli/admin.py
+++ b/cometx/cli/admin.py
@@ -464,7 +464,9 @@ Examples:
     )
 
     # growth-report subcommand
-    growth_report_description = """Generate a cross-platform use-case growth report for one or more workspaces.
+    growth_report_description = """\
+Generate an org-wide people/usage growth report from the admin \
+chargeback report.
 
 Arguments:
     WORKSPACE (optional, one or more)
@@ -488,7 +490,10 @@ Examples:
 """
     growth_parser = subparsers.add_parser(
         "growth-report",
-        help="Generate a cross-platform use-case growth report for one or more workspaces",
+        help=(
+            "Generate an org-wide people/usage growth report from the "
+            "admin chargeback report"
+        ),
         description=growth_report_description,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/cometx/cli/admin.py
+++ b/cometx/cli/admin.py
@@ -155,7 +155,7 @@ from comet_ml import API
 from cometx.utils import fetch_chargeback_report
 
 from .admin_gpu_report import main as gpu_report_main
-from .admin_growth_report import generate_growth_report
+from .admin_growth_report import GrowthReportError, generate_growth_report
 from .admin_optimizer_report import generate_json_report
 from .admin_usage_report import generate_usage_report
 
@@ -471,16 +471,19 @@ Arguments:
         One or more workspaces to run the growth report for.
         If not provided, all workspaces are included.
 
+Requires an ADMIN API key: the report is built entirely from the admin
+chargeback report. Without admin access the command exits with an error.
+
 Output:
-    Generates a self-contained HTML page containing cross-platform (Opik + EM + MPM)
-    use-case growth and rate charts, broken down by workspace/department.
+    Generates a self-contained HTML page with the organization overview, users,
+    personal-vs-service, and leaderboard sections, all derived from the admin
+    chargeback report and broken down by workspace/department.
 
 Examples:
     cometx admin growth-report
     cometx admin growth-report my-workspace
     cometx admin growth-report workspace1 workspace2 --units week
     cometx admin growth-report my-workspace --window 30d
-    cometx admin growth-report my-workspace --platforms em,opik
     cometx admin growth-report my-workspace --output report.html --no-open
 """
     growth_parser = subparsers.add_parser(
@@ -512,22 +515,10 @@ Examples:
         type=str,
     )
     growth_parser.add_argument(
-        "--platforms",
-        help="Comma-separated list of platforms to include (default: em,opik,mpm)",
-        default="em,opik,mpm",
-        type=str,
-    )
-    growth_parser.add_argument(
         "--output",
         help="Output HTML file path (default: growth_report.html)",
         default="growth_report.html",
         type=str,
-    )
-    growth_parser.add_argument(
-        "--limit",
-        help="Optional limit on the number of items collected per platform",
-        type=int,
-        default=None,
     )
     growth_parser.add_argument(
         "--active-window",
@@ -539,13 +530,6 @@ Examples:
         type=int,
         default=5,
         help="Top/bottom N size for leaderboards (default: 5)",
-    )
-    growth_parser.add_argument(
-        "--no-users",
-        dest="include_users",
-        action="store_false",
-        default=True,
-        help="Skip the chargeback-based users/people layer",
     )
     growth_parser.add_argument(
         "--exclude-personal",
@@ -841,16 +825,16 @@ def admin(parsed_args, remaining=None):
                     parsed_args.WORKSPACE,
                     window=parsed_args.window,
                     units=parsed_args.units,
-                    platforms=parsed_args.platforms,
                     output=parsed_args.output,
                     no_open=parsed_args.no_open,
-                    limit=parsed_args.limit,
                     active_window=parsed_args.active_window,
-                    include_users=parsed_args.include_users,
                     leaderboard_top_n=parsed_args.leaderboard_top_n,
                     exclude_personal=parsed_args.exclude_personal,
                     personal_pattern=parsed_args.personal_pattern,
                 )
+            except GrowthReportError as e:
+                print("ERROR: " + str(e))
+                sys.exit(1)
             except Exception as e:
                 print("ERROR: " + str(e))
                 if parsed_args.debug:

--- a/cometx/cli/admin_growth_render.py
+++ b/cometx/cli/admin_growth_render.py
@@ -21,11 +21,11 @@ and server-rendered KPI/table/panel markup. No external assets, no network
 calls, no secrets -- `report_data` never carries an API key.
 
 Charts render as plain month-on-month / week-on-week series with horizontal
-gridlines for scale. The earlier single-analysis-window overlay (a shaded
-`[window_start, window_end]` band with accent-vs-muted fill and start/end
-dots) has been removed now that the report is period-over-period; the
-`window_start`/`window_end` fields in chart data are retained but no longer
-drawn. A window chip is still rendered next to each section title.
+gridlines for scale. An earlier single-analysis-window overlay (a shaded
+band with start/end dots) was removed once the report became
+period-over-period; the now-defunct `window_start`/`window_end` chart-data
+fields were dropped with it. A window chip is still rendered next to each
+section title.
 """
 
 from __future__ import annotations
@@ -207,17 +207,6 @@ CLIENT_JS = """
     return node;
   }
   function fmt(n){ return (n || 0).toLocaleString("en-US"); }
-  function indexOfKey(points, key){
-    if(key === undefined || key === null) return -1;
-    for(var i = 0; i < points.length; i++){ if(points[i].key === key) return i; }
-    return -1;
-  }
-  function keyInRange(key, start, end){
-    if(key === undefined || key === null) return false;
-    if(start !== undefined && start !== null && key < start) return false;
-    if(end !== undefined && end !== null && key > end) return false;
-    return true;
-  }
 
   var W = 560, H = 220, P = {t: 16, r: 14, b: 28, l: 44};
 
@@ -232,7 +221,7 @@ CLIENT_JS = """
     var guide = el("line", {class: "guide", y1: P.t, y2: H - P.b, x1: 0, x2: 0, opacity: "0"});
     svg.appendChild(guide);
     function show(col){
-      tip.textContent = col.key + ": " + fmt(col.value);
+      tip.textContent = col.label || (col.key + ": " + fmt(col.value));
       tip.classList.add("show");
       var r = host.getBoundingClientRect();
       tip.style.left = (col.x / W) * r.width + "px";
@@ -261,10 +250,22 @@ CLIENT_JS = """
     }
   }
 
+  // Right-hand axis ticks (unlabelled gridlines omitted; the left axis owns
+  // the grid) for a secondary series drawn on its own scale. `suffix` labels
+  // the units, e.g. "%". Colored to match the series it measures.
+  function rAxis(svg, yOf, maxVal, iw, suffix, color){
+    for(var g = 1; g <= 4; g++){
+      var v = maxVal * g / 4, y = yOf(v);
+      var t = el("text", {x: P.l + iw + 6, y: y + 3, "text-anchor": "start",
+        fill: color || tok("--muted"), "font-size": "10", "font-family": "var(--mono)"});
+      t.textContent = fmt(Math.round(v)) + (suffix || ""); svg.appendChild(t);
+    }
+  }
+
   function drawBars(host, data){
     data = data || {}; var points = data.points || [];
     if(!points.length){ host.innerHTML = "<p class=\\"nodata\\">No data</p>"; return; }
-    var accent = tok("--accent"), mute = tok("--bar-mute"), band = tok("--accent-soft");
+    var accent = tok("--accent");
     var svg = el("svg", {viewBox: "0 0 " + W + " " + H, role: "img"});
     var iw = W - P.l - P.r, ih = H - P.t - P.b, n = points.length;
     var max = 1; points.forEach(function(p){ max = Math.max(max, p.value || 0); });
@@ -290,7 +291,6 @@ CLIENT_JS = """
     data = data || {}; var points = data.points || []; var cats = data.categories || [];
     if(!points.length || !cats.length){ host.innerHTML = "<p class=\\"nodata\\">No data</p>"; return; }
     var colors = (data.colors && data.colors.length) ? data.colors : ["--accent", "--sdk", "--ok", "--warn"];
-    var accent = tok("--accent"), band = tok("--accent-soft");
     var svg = el("svg", {viewBox: "0 0 " + W + " " + H, role: "img"});
     var iw = W - P.l - P.r, ih = H - P.t - P.b, n = points.length;
     var max = 1;
@@ -321,6 +321,16 @@ CLIENT_JS = """
         fill: tok("--muted"), "font-size": "10", "font-family": "var(--mono)"});
       xl.textContent = points[i].key; svg.appendChild(xl);
     });
+    // Per-x tooltips: one column spanning the gap around each point, listing
+    // every category's value at that x.
+    var labels = data.labels || {};
+    var slot = n > 1 ? iw / (n - 1) : iw;
+    var cols = points.map(function(p, i){
+      var parts = [p.key];
+      cats.forEach(function(c){ parts.push((labels[c] || c) + " " + fmt((p.values && p.values[c]) || 0)); });
+      return {x: X(i), x0: X(i) - slot / 2, w: slot, key: p.key, label: parts.join("  \\u00b7  ")};
+    });
+    attachTip(host, svg, cols);
     host.appendChild(svg);
   }
 
@@ -373,8 +383,13 @@ CLIENT_JS = """
     if(!points.length || !bars.length){ host.innerHTML = "<p class=\\"nodata\\">No data</p>"; return; }
     var barColors = (data.bar_colors && data.bar_colors.length) ? data.bar_colors : ["--ok", "--warn"];
     var lineColor = data.line_color || "--accent";
+    var lineSuffix = data.line_suffix || "";
+    var barLabels = data.bar_labels || {};
     var svg = el("svg", {viewBox: "0 0 " + W + " " + H, role: "img"});
-    var iw = W - P.l - P.r, ih = H - P.t - P.b, n = points.length;
+    // Reserve extra right margin for the secondary (line) axis labels when a
+    // line is present, so they don't collide with the plot area.
+    var rpad = lineCat ? 34 : 0;
+    var iw = W - P.l - P.r - rpad, ih = H - P.t - P.b, n = points.length;
     var lmax = 1, rmax = 1;
     points.forEach(function(p){
       bars.forEach(function(b){ lmax = Math.max(lmax, (p.values && p.values[b]) || 0); });
@@ -385,7 +400,9 @@ CLIENT_JS = """
     var YR = function(v){ return P.t + ih * (1 - v / rmax); };
     var cx = function(i){ return P.l + slot * i + slot / 2; };
     hGrid(svg, YL, lmax, iw);
+    if(lineCat) rAxis(svg, YR, rmax, iw, lineSuffix, tok(lineColor));
     svg.appendChild(el("line", {class: "axis-base", x1: P.l, x2: P.l + iw, y1: P.t + ih, y2: P.t + ih}));
+    var cols = [];
     points.forEach(function(p, i){
       var gx = P.l + slot * i + (slot - group) / 2;
       bars.forEach(function(b, bi){
@@ -394,6 +411,11 @@ CLIENT_JS = """
         svg.appendChild(el("rect", {x: gx + bw * bi, y: P.t + ih - h, width: Math.max(bw - 2, 1),
           height: h, rx: "2", fill: tok(barColors[bi % barColors.length])}));
       });
+      // Per-column tooltip label: each bar series + the line value.
+      var parts = [p.key];
+      bars.forEach(function(b){ parts.push((barLabels[b] || b) + " " + fmt((p.values && p.values[b]) || 0)); });
+      if(lineCat){ parts.push((barLabels[lineCat] || lineCat) + " " + fmt((p.values && p.values[lineCat]) || 0) + lineSuffix); }
+      cols.push({x: cx(i), x0: P.l + slot * i, w: slot, key: p.key, label: parts.join("  \\u00b7  ")});
       if(i % Math.max(1, Math.ceil(n / 8)) === 0){
         var t = el("text", {x: cx(i), y: H - 8, "text-anchor": "middle", fill: tok("--muted"),
           "font-size": "10", "font-family": "var(--mono)"});
@@ -409,6 +431,7 @@ CLIENT_JS = """
         svg.appendChild(el("circle", {cx: cx(i), cy: YR((p.values && p.values[lineCat]) || 0), r: "2.5", fill: tok(lineColor)}));
       });
     }
+    attachTip(host, svg, cols);
     host.appendChild(svg);
   }
 

--- a/cometx/cli/admin_growth_render.py
+++ b/cometx/cli/admin_growth_render.py
@@ -496,6 +496,7 @@ CLIENT_JS = """
     function add(section){ if(section && section.charts){ section.charts.forEach(function(c){ out.push(c); }); } }
     var sections = (p && p.sections) || {};
     add(sections.unified);
+    add(sections.people);
     var products = sections.products || {};
     ["opik", "em", "mpm"].forEach(function(k){
       var prod = products[k]; if(!prod) return;

--- a/cometx/cli/admin_growth_render.py
+++ b/cometx/cli/admin_growth_render.py
@@ -20,10 +20,12 @@ inline JS that draws the charts as inline SVG from an embedded JSON payload,
 and server-rendered KPI/table/panel markup. No external assets, no network
 calls, no secrets -- `report_data` never carries an API key.
 
-Charts implement Option-A window rendering: a dashed accent-tinted band over
-`[window_start, window_end]`, accent-vs-muted bar fill inside/outside the
-window, hollow/filled start/end dots + a `Delta +N` label on cumulative
-charts, and a window chip rendered next to each section title.
+Charts render as plain month-on-month / week-on-week series with horizontal
+gridlines for scale. The earlier single-analysis-window overlay (a shaded
+`[window_start, window_end]` band with accent-vs-muted fill and start/end
+dots) has been removed now that the report is period-over-period; the
+`window_start`/`window_end` fields in chart data are retained but no longer
+drawn. A window chip is still rendered next to each section title.
 """
 
 from __future__ import annotations
@@ -254,6 +256,16 @@ CLIENT_JS = """
     });
   }
 
+  function hGrid(svg, yOf, maxVal, iw){
+    for(var g = 1; g <= 4; g++){
+      var v = maxVal * g / 4, y = yOf(v);
+      svg.appendChild(el("line", {class: "gridline", x1: P.l, x2: P.l + iw, y1: y, y2: y}));
+      var t = el("text", {x: P.l - 6, y: y + 3, "text-anchor": "end", fill: tok("--muted"),
+        "font-size": "10", "font-family": "var(--mono)"});
+      t.textContent = fmt(v); svg.appendChild(t);
+    }
+  }
+
   function drawBars(host, data){
     data = data || {}; var points = data.points || [];
     if(!points.length){ host.innerHTML = "<p class=\\"nodata\\">No data</p>"; return; }
@@ -262,19 +274,12 @@ CLIENT_JS = """
     var iw = W - P.l - P.r, ih = H - P.t - P.b, n = points.length;
     var max = 1; points.forEach(function(p){ max = Math.max(max, p.value || 0); });
     var slot = iw / n, bw = Math.min(38, slot * 0.55);
+    hGrid(svg, function(v){ return P.t + ih * (1 - v / max); }, max, iw);
     svg.appendChild(el("line", {class: "axis-base", x1: P.l, x2: P.l + iw, y1: P.t + ih, y2: P.t + ih}));
-    var wi0 = indexOfKey(points, data.window_start), wi1 = indexOfKey(points, data.window_end);
-    if(wi0 > -1 && wi1 > -1){
-      var bx0 = P.l + slot * wi0, bx1 = P.l + slot * (wi1 + 1);
-      svg.appendChild(el("rect", {x: bx0, y: P.t, width: (bx1 - bx0), height: ih, fill: band,
-        stroke: accent, "stroke-dasharray": "4 3", "stroke-width": "1", rx: "3"}));
-    }
     var cols = [];
     points.forEach(function(p, i){
       var v = p.value || 0, h = ih * (v / max), x = P.l + slot * i + (slot - bw) / 2, y = P.t + ih - h;
-      var inWin = p.in_window;
-      if(inWin === undefined || inWin === null) inWin = keyInRange(p.key, data.window_start, data.window_end);
-      svg.appendChild(el("rect", {x: x, y: y, width: bw, height: Math.max(h, 0), rx: "3", fill: inWin ? accent : mute}));
+      svg.appendChild(el("rect", {x: x, y: y, width: bw, height: Math.max(h, 0), rx: "3", fill: accent}));
       cols.push({x: P.l + slot * i + slot / 2, x0: P.l + slot * i, w: slot, key: p.key, value: v});
       if(i % Math.max(1, Math.ceil(n / 8)) === 0){
         var t = el("text", {x: x + bw / 2, y: H - 8, "text-anchor": "middle", fill: tok("--muted"),
@@ -295,44 +300,21 @@ CLIENT_JS = """
     var max = 1; points.forEach(function(p){ max = Math.max(max, p.value || 0); });
     var X = function(i){ return n > 1 ? P.l + iw * (i / (n - 1)) : P.l + iw / 2; };
     var Y = function(v){ return P.t + ih * (1 - v / max); };
+    hGrid(svg, Y, max, iw);
     svg.appendChild(el("line", {class: "axis-base", x1: P.l, x2: P.l + iw, y1: P.t + ih, y2: P.t + ih}));
-    var wi0 = indexOfKey(points, data.window_start), wi1 = indexOfKey(points, data.window_end);
-    if(wi0 > -1 && wi1 > -1){
-      svg.appendChild(el("rect", {x: X(wi0), y: P.t, width: Math.max(X(wi1) - X(wi0), 1), height: ih,
-        fill: band, stroke: accent, "stroke-dasharray": "4 3", "stroke-width": "1", rx: "3"}));
-    }
     var dp = "M" + X(0) + " " + Y(points[0].value || 0);
     points.forEach(function(p, i){ if(i) dp += " L" + X(i) + " " + Y(p.value || 0); });
     var area = dp + " L" + X(n - 1) + " " + (P.t + ih) + " L" + X(0) + " " + (P.t + ih) + " Z";
     svg.appendChild(el("path", {d: area, fill: accent, opacity: "0.12"}));
     svg.appendChild(el("path", {d: dp, fill: "none", stroke: accent, "stroke-width": "2",
       "stroke-linejoin": "round", "stroke-linecap": "round"}));
-    if(wi0 > -1){
-      svg.appendChild(el("circle", {cx: X(wi0), cy: Y(points[wi0].value || 0), r: "4", fill: tok("--card"),
-        stroke: accent, "stroke-width": "2"}));
-    }
-    if(wi1 > -1){
-      svg.appendChild(el("circle", {cx: X(wi1), cy: Y(points[wi1].value || 0), r: "4", fill: accent,
-        stroke: tok("--card"), "stroke-width": "2"}));
-      if(data.delta !== undefined && data.delta !== null){
-        var t = el("text", {x: X(wi1) + 8, y: Y(points[wi1].value || 0) - 8, "text-anchor": "start",
-          fill: accent, "font-size": "11", "font-family": "var(--mono)", "font-weight": "600"});
-        t.textContent = "\\u0394 +" + fmt(data.delta);
-        svg.appendChild(t);
-      }
-    }
-    // y max gridline + label so the scale is readable
-    svg.appendChild(el("line", {class: "gridline", x1: P.l, x2: P.l + iw, y1: Y(max), y2: Y(max)}));
-    var maxL = el("text", {x: P.l - 6, y: Y(max) + 3, "text-anchor": "end", fill: tok("--muted"),
-      "font-size": "10", "font-family": "var(--mono)"});
-    maxL.textContent = fmt(max); svg.appendChild(maxL);
-    // final cumulative value label (skip if it would collide with the window-end marker)
+    // final cumulative value label + end marker
     var endV = points[n - 1].value || 0;
-    if(wi1 < 0){
-      var eL = el("text", {x: X(n - 1), y: Y(endV) - 8, "text-anchor": "end", fill: accent,
-        "font-size": "11", "font-family": "var(--mono)", "font-weight": "600"});
-      eL.textContent = fmt(endV); svg.appendChild(eL);
-    }
+    var eL = el("text", {x: X(n - 1), y: Y(endV) - 8, "text-anchor": "end", fill: accent,
+      "font-size": "11", "font-family": "var(--mono)", "font-weight": "600"});
+    eL.textContent = fmt(endV); svg.appendChild(eL);
+    svg.appendChild(el("circle", {cx: X(n - 1), cy: Y(endV), r: "4", fill: accent,
+      stroke: tok("--card"), "stroke-width": "2"}));
     // x-axis: cumulative charts show only the earliest and latest dates
     var slotA = n > 1 ? iw / (n - 1) : iw;
     [0, n - 1].forEach(function(i){
@@ -361,22 +343,15 @@ CLIENT_JS = """
     });
     var max = Math.max.apply(null, totals.concat([1]));
     var slot = iw / n, bw = Math.min(38, slot * 0.55);
+    hGrid(svg, function(v){ return P.t + ih * (1 - v / max); }, max, iw);
     svg.appendChild(el("line", {class: "axis-base", x1: P.l, x2: P.l + iw, y1: P.t + ih, y2: P.t + ih}));
-    var wi0 = indexOfKey(points, data.window_start), wi1 = indexOfKey(points, data.window_end);
-    if(wi0 > -1 && wi1 > -1){
-      var bx0 = P.l + slot * wi0, bx1 = P.l + slot * (wi1 + 1);
-      svg.appendChild(el("rect", {x: bx0, y: P.t, width: (bx1 - bx0), height: ih, fill: band,
-        stroke: accent, "stroke-dasharray": "4 3", "stroke-width": "1", rx: "3"}));
-    }
     var cols = [];
     points.forEach(function(p, i){
       var x = P.l + slot * i + (slot - bw) / 2, yCursor = P.t + ih;
-      var inWin = keyInRange(p.key, data.window_start, data.window_end);
       cats.forEach(function(c, ci){
         var v = (p.values && p.values[c]) || 0; if(!v) return;
         var h = ih * (v / max), y = yCursor - h;
-        svg.appendChild(el("rect", {x: x, y: y, width: bw, height: h, fill: tok(colors[ci % colors.length]),
-          opacity: inWin ? "1" : "0.45"}));
+        svg.appendChild(el("rect", {x: x, y: y, width: bw, height: h, fill: tok(colors[ci % colors.length])}));
         yCursor = y;
       });
       cols.push({x: P.l + slot * i + slot / 2, x0: P.l + slot * i, w: slot, key: p.key, value: totals[i]});
@@ -403,17 +378,8 @@ CLIENT_JS = """
     });
     var X = function(i){ return n > 1 ? P.l + iw * (i / (n - 1)) : P.l + iw / 2; };
     var Y = function(v){ return P.t + ih * (1 - v / max); };
+    hGrid(svg, Y, max, iw);
     svg.appendChild(el("line", {class: "axis-base", x1: P.l, x2: P.l + iw, y1: P.t + ih, y2: P.t + ih}));
-    var wi0 = indexOfKey(points, data.window_start), wi1 = indexOfKey(points, data.window_end);
-    if(wi0 > -1 && wi1 > -1){
-      svg.appendChild(el("rect", {x: X(wi0), y: P.t, width: Math.max(X(wi1) - X(wi0), 1), height: ih,
-        fill: band, stroke: accent, "stroke-dasharray": "4 3", "stroke-width": "1", rx: "3"}));
-    }
-    // y max gridline + label so the scale is readable
-    svg.appendChild(el("line", {class: "gridline", x1: P.l, x2: P.l + iw, y1: Y(max), y2: Y(max)}));
-    var maxL = el("text", {x: P.l - 6, y: Y(max) + 3, "text-anchor": "end", fill: tok("--muted"),
-      "font-size": "10", "font-family": "var(--mono)"});
-    maxL.textContent = fmt(max); svg.appendChild(maxL);
     // one polyline per category
     cats.forEach(function(c, ci){
       var col = tok(colors[ci % colors.length]);
@@ -480,6 +446,51 @@ CLIENT_JS = """
     host.appendChild(svg);
   }
 
+  function drawBarsLine(host, data){
+    data = data || {}; var points = data.points || []; var bars = data.bars || [];
+    var lineCat = data.line;
+    if(!points.length || !bars.length){ host.innerHTML = "<p class=\\"nodata\\">No data</p>"; return; }
+    var barColors = (data.bar_colors && data.bar_colors.length) ? data.bar_colors : ["--ok", "--warn"];
+    var lineColor = data.line_color || "--accent";
+    var svg = el("svg", {viewBox: "0 0 " + W + " " + H, role: "img"});
+    var iw = W - P.l - P.r, ih = H - P.t - P.b, n = points.length;
+    var lmax = 1, rmax = 1;
+    points.forEach(function(p){
+      bars.forEach(function(b){ lmax = Math.max(lmax, (p.values && p.values[b]) || 0); });
+      rmax = Math.max(rmax, (p.values && p.values[lineCat]) || 0);
+    });
+    var slot = iw / n, group = Math.min(slot * 0.7, 40), bw = group / bars.length;
+    var YL = function(v){ return P.t + ih * (1 - v / lmax); };
+    var YR = function(v){ return P.t + ih * (1 - v / rmax); };
+    var cx = function(i){ return P.l + slot * i + slot / 2; };
+    hGrid(svg, YL, lmax, iw);
+    svg.appendChild(el("line", {class: "axis-base", x1: P.l, x2: P.l + iw, y1: P.t + ih, y2: P.t + ih}));
+    points.forEach(function(p, i){
+      var gx = P.l + slot * i + (slot - group) / 2;
+      bars.forEach(function(b, bi){
+        var v = (p.values && p.values[b]) || 0; if(v <= 0) return;
+        var h = ih * (v / lmax);
+        svg.appendChild(el("rect", {x: gx + bw * bi, y: P.t + ih - h, width: Math.max(bw - 2, 1),
+          height: h, rx: "2", fill: tok(barColors[bi % barColors.length])}));
+      });
+      if(i % Math.max(1, Math.ceil(n / 8)) === 0){
+        var t = el("text", {x: cx(i), y: H - 8, "text-anchor": "middle", fill: tok("--muted"),
+          "font-size": "10", "font-family": "var(--mono)"});
+        t.textContent = p.key; svg.appendChild(t);
+      }
+    });
+    if(lineCat){
+      var dp = "";
+      points.forEach(function(p, i){ dp += (i ? " L" : "M") + cx(i) + " " + YR((p.values && p.values[lineCat]) || 0); });
+      svg.appendChild(el("path", {d: dp, fill: "none", stroke: tok(lineColor), "stroke-width": "2",
+        "stroke-linejoin": "round", "stroke-linecap": "round"}));
+      points.forEach(function(p, i){
+        svg.appendChild(el("circle", {cx: cx(i), cy: YR((p.values && p.values[lineCat]) || 0), r: "2.5", fill: tok(lineColor)}));
+      });
+    }
+    host.appendChild(svg);
+  }
+
   function drawChart(c){
     if(!c || !c.id) return;
     var host = document.getElementById(c.id); if(!host) return;
@@ -488,6 +499,7 @@ CLIENT_JS = """
     else if(c.kind === "area") drawArea(host, c.data);
     else if(c.kind === "stackedBars") drawStacked(host, c.data);
     else if(c.kind === "lines") drawLines(host, c.data);
+    else if(c.kind === "barsLine") drawBarsLine(host, c.data);
     else if(c.kind === "groupedBarsH") drawGroupedH(host, c.data);
   }
 
@@ -648,6 +660,8 @@ def render_topbar(report_data: dict) -> str:
     meta_bits = []
     if meta.get("org"):
         meta_bits.append(f'<span>Organization <b>{_esc(meta["org"])}</b></span>')
+    if meta.get("scope"):
+        meta_bits.append(f'<span>Scope <b>{_esc(meta["scope"])}</b></span>')
     if window.get("label"):
         meta_bits.append(
             f'<span>Window <b class="mono">{_esc(window["label"])}</b></span>'

--- a/cometx/cli/admin_growth_render.py
+++ b/cometx/cli/admin_growth_render.py
@@ -498,6 +498,7 @@ CLIENT_JS = """
     add(sections.unified);
     add(sections.people);
     add(sections.leaderboards);
+    add(sections.personal_vs_service);
     var products = sections.products || {};
     ["opik", "em", "mpm"].forEach(function(k){
       var prod = products[k]; if(!prod) return;
@@ -694,6 +695,7 @@ def build_html(report_data: dict) -> str:
         render_section(sections.get("unified")),
         render_section(sections.get("people")),
         render_section(sections.get("leaderboards")),
+        render_section(sections.get("personal_vs_service")),
     ]
 
     for key in PLATFORM_ORDER:

--- a/cometx/cli/admin_growth_render.py
+++ b/cometx/cli/admin_growth_render.py
@@ -497,6 +497,7 @@ CLIENT_JS = """
     var sections = (p && p.sections) || {};
     add(sections.unified);
     add(sections.people);
+    add(sections.leaderboards);
     var products = sections.products || {};
     ["opik", "em", "mpm"].forEach(function(k){
       var prod = products[k]; if(!prod) return;
@@ -692,6 +693,7 @@ def build_html(report_data: dict) -> str:
         render_topbar(report_data),
         render_section(sections.get("unified")),
         render_section(sections.get("people")),
+        render_section(sections.get("leaderboards")),
     ]
 
     for key in PLATFORM_ORDER:

--- a/cometx/cli/admin_growth_render.py
+++ b/cometx/cli/admin_growth_render.py
@@ -33,8 +33,6 @@ from __future__ import annotations
 import html
 import json
 
-PLATFORM_ORDER = ("opik", "em", "mpm")
-
 DEFAULT_PALETTE = ("--accent", "--sdk", "--ok", "--warn")
 
 
@@ -119,7 +117,6 @@ h1{font-size:26px;line-height:1.15;margin:0;letter-spacing:-.015em;font-weight:6
   border:1px solid var(--hair);border-radius:7px;padding:7px 11px;cursor:pointer;display:inline-flex;
   gap:7px;align-items:center}
 .toggle:hover{border-color:var(--accent);color:var(--ink)}
-.collectors{display:flex;flex-wrap:wrap;gap:7px}
 .chip{display:inline-flex;align-items:center;gap:6px;font-size:12px;font-family:var(--mono);
   padding:4px 9px;border-radius:999px;border:1px solid var(--hair);color:var(--ink-2);background:var(--card)}
 .chip .dot{width:7px;height:7px;border-radius:50%}
@@ -127,8 +124,6 @@ h1{font-size:26px;line-height:1.15;margin:0;letter-spacing:-.015em;font-weight:6
 .chip.winchip{color:var(--ink);border-color:color-mix(in srgb,var(--accent) 40%,var(--hair))}
 .sec-head{display:flex;flex-wrap:wrap;align-items:baseline;gap:10px;margin:30px 0 14px}
 .sec-title{font-size:18px;margin:0;font-weight:650;letter-spacing:-.01em}
-.product-heading{font-size:20px;margin:38px 0 4px;font-weight:700;letter-spacing:-.01em;
-  border-top:1px solid var(--hair);padding-top:22px}
 .kpis{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin-bottom:16px}
 .kpi{background:var(--card);border:1px solid var(--hair);border-radius:12px;padding:16px 16px 14px;
   box-shadow:var(--shadow);position:relative;overflow:hidden}
@@ -291,80 +286,6 @@ CLIENT_JS = """
     host.appendChild(svg);
   }
 
-  function drawArea(host, data){
-    data = data || {}; var points = data.points || [];
-    if(!points.length){ host.innerHTML = "<p class=\\"nodata\\">No data</p>"; return; }
-    var accent = tok("--accent"), band = tok("--accent-soft");
-    var svg = el("svg", {viewBox: "0 0 " + W + " " + H, role: "img"});
-    var iw = W - P.l - P.r, ih = H - P.t - P.b, n = points.length;
-    var max = 1; points.forEach(function(p){ max = Math.max(max, p.value || 0); });
-    var X = function(i){ return n > 1 ? P.l + iw * (i / (n - 1)) : P.l + iw / 2; };
-    var Y = function(v){ return P.t + ih * (1 - v / max); };
-    hGrid(svg, Y, max, iw);
-    svg.appendChild(el("line", {class: "axis-base", x1: P.l, x2: P.l + iw, y1: P.t + ih, y2: P.t + ih}));
-    var dp = "M" + X(0) + " " + Y(points[0].value || 0);
-    points.forEach(function(p, i){ if(i) dp += " L" + X(i) + " " + Y(p.value || 0); });
-    var area = dp + " L" + X(n - 1) + " " + (P.t + ih) + " L" + X(0) + " " + (P.t + ih) + " Z";
-    svg.appendChild(el("path", {d: area, fill: accent, opacity: "0.12"}));
-    svg.appendChild(el("path", {d: dp, fill: "none", stroke: accent, "stroke-width": "2",
-      "stroke-linejoin": "round", "stroke-linecap": "round"}));
-    // final cumulative value label + end marker
-    var endV = points[n - 1].value || 0;
-    var eL = el("text", {x: X(n - 1), y: Y(endV) - 8, "text-anchor": "end", fill: accent,
-      "font-size": "11", "font-family": "var(--mono)", "font-weight": "600"});
-    eL.textContent = fmt(endV); svg.appendChild(eL);
-    svg.appendChild(el("circle", {cx: X(n - 1), cy: Y(endV), r: "4", fill: accent,
-      stroke: tok("--card"), "stroke-width": "2"}));
-    // x-axis: cumulative charts show only the earliest and latest dates
-    var slotA = n > 1 ? iw / (n - 1) : iw;
-    [0, n - 1].forEach(function(i){
-      if(i < 0) return;
-      var xl = el("text", {x: X(i), y: H - 8, "text-anchor": i === 0 ? "start" : "end",
-        fill: tok("--muted"), "font-size": "10", "font-family": "var(--mono)"});
-      xl.textContent = points[i].key; svg.appendChild(xl);
-    });
-    // interactive hover tooltip over each point
-    var cols = points.map(function(p, i){
-      return {x: X(i), x0: X(i) - slotA / 2, w: slotA, key: p.key, value: p.value || 0};
-    });
-    attachTip(host, svg, cols);
-    host.appendChild(svg);
-  }
-
-  function drawStacked(host, data){
-    data = data || {}; var points = data.points || []; var cats = data.categories || [];
-    if(!points.length || !cats.length){ host.innerHTML = "<p class=\\"nodata\\">No data</p>"; return; }
-    var colors = (data.colors && data.colors.length) ? data.colors : ["--accent", "--sdk", "--ok", "--warn"];
-    var accent = tok("--accent"), band = tok("--accent-soft");
-    var svg = el("svg", {viewBox: "0 0 " + W + " " + H, role: "img"});
-    var iw = W - P.l - P.r, ih = H - P.t - P.b, n = points.length;
-    var totals = points.map(function(p){
-      var s = 0; cats.forEach(function(c){ s += (p.values && p.values[c]) || 0; }); return s;
-    });
-    var max = Math.max.apply(null, totals.concat([1]));
-    var slot = iw / n, bw = Math.min(38, slot * 0.55);
-    hGrid(svg, function(v){ return P.t + ih * (1 - v / max); }, max, iw);
-    svg.appendChild(el("line", {class: "axis-base", x1: P.l, x2: P.l + iw, y1: P.t + ih, y2: P.t + ih}));
-    var cols = [];
-    points.forEach(function(p, i){
-      var x = P.l + slot * i + (slot - bw) / 2, yCursor = P.t + ih;
-      cats.forEach(function(c, ci){
-        var v = (p.values && p.values[c]) || 0; if(!v) return;
-        var h = ih * (v / max), y = yCursor - h;
-        svg.appendChild(el("rect", {x: x, y: y, width: bw, height: h, fill: tok(colors[ci % colors.length])}));
-        yCursor = y;
-      });
-      cols.push({x: P.l + slot * i + slot / 2, x0: P.l + slot * i, w: slot, key: p.key, value: totals[i]});
-      if(i % Math.max(1, Math.ceil(n / 8)) === 0){
-        var t = el("text", {x: x + bw / 2, y: H - 8, "text-anchor": "middle", fill: tok("--muted"),
-          "font-size": "10", "font-family": "var(--mono)"});
-        t.textContent = p.key; svg.appendChild(t);
-      }
-    });
-    attachTip(host, svg, cols);
-    host.appendChild(svg);
-  }
-
   function drawLines(host, data){
     data = data || {}; var points = data.points || []; var cats = data.categories || [];
     if(!points.length || !cats.length){ host.innerHTML = "<p class=\\"nodata\\">No data</p>"; return; }
@@ -496,8 +417,6 @@ CLIENT_JS = """
     var host = document.getElementById(c.id); if(!host) return;
     host.innerHTML = "";
     if(c.kind === "bars") drawBars(host, c.data);
-    else if(c.kind === "area") drawArea(host, c.data);
-    else if(c.kind === "stackedBars") drawStacked(host, c.data);
     else if(c.kind === "lines") drawLines(host, c.data);
     else if(c.kind === "barsLine") drawBarsLine(host, c.data);
     else if(c.kind === "groupedBarsH") drawGroupedH(host, c.data);
@@ -511,11 +430,6 @@ CLIENT_JS = """
     add(sections.people);
     add(sections.leaderboards);
     add(sections.personal_vs_service);
-    var products = sections.products || {};
-    ["opik", "em", "mpm"].forEach(function(k){
-      var prod = products[k]; if(!prod) return;
-      add(prod.growth); add(prod.adoption);
-    });
     return out;
   }
 
@@ -654,7 +568,6 @@ def render_section(section) -> str:
 def render_topbar(report_data: dict) -> str:
     meta = report_data.get("meta") or {}
     window = report_data.get("window") or {}
-    collectors = report_data.get("collectors") or {}
 
     title = _esc(meta.get("title") or "Growth report")
     meta_bits = []
@@ -673,13 +586,6 @@ def render_topbar(report_data: dict) -> str:
     if meta.get("source"):
         meta_bits.append(f'<span>Source <b>{_esc(meta["source"])}</b></span>')
 
-    chips = "".join(
-        '<span class="chip {}"><span class="dot"></span>{}</span>'.format(
-            "on" if bool(value) else "off", _esc(key)
-        )
-        for key, value in collectors.items()
-    )
-
     return (
         '<div class="topbar"><div>'
         '<p class="eyebrow">Comet Growth Report</p>'
@@ -690,7 +596,6 @@ def render_topbar(report_data: dict) -> str:
         '<button class="toggle" id="themeBtn" aria-label="Toggle color theme">'
         '<span id="themeIcon">◑</span><span id="themeLbl">Theme</span>'
         "</button>"
-        f'<div class="collectors" aria-label="collector status">{chips}</div>'
         "</div></div>"
     )
 
@@ -702,7 +607,6 @@ def build_html(report_data: dict) -> str:
     """
     report_data = report_data or {}
     sections = report_data.get("sections") or {}
-    products = sections.get("products") or {}
 
     body_parts = [
         render_topbar(report_data),
@@ -711,18 +615,6 @@ def build_html(report_data: dict) -> str:
         render_section(sections.get("leaderboards")),
         render_section(sections.get("personal_vs_service")),
     ]
-
-    for key in PLATFORM_ORDER:
-        product = products.get(key)
-        if not product:
-            continue
-        label = _esc(product.get("label") or key.upper())
-        product_html = render_section(product.get("growth")) + render_section(
-            product.get("adoption")
-        )
-        if product_html:
-            body_parts.append(f'<h2 class="product-heading">{label}</h2>')
-            body_parts.append(product_html)
 
     body_parts.append(FOOTER_HTML)
 

--- a/cometx/cli/admin_growth_render.py
+++ b/cometx/cli/admin_growth_render.py
@@ -390,6 +390,53 @@ CLIENT_JS = """
     host.appendChild(svg);
   }
 
+  function drawLines(host, data){
+    data = data || {}; var points = data.points || []; var cats = data.categories || [];
+    if(!points.length || !cats.length){ host.innerHTML = "<p class=\\"nodata\\">No data</p>"; return; }
+    var colors = (data.colors && data.colors.length) ? data.colors : ["--accent", "--sdk", "--ok", "--warn"];
+    var accent = tok("--accent"), band = tok("--accent-soft");
+    var svg = el("svg", {viewBox: "0 0 " + W + " " + H, role: "img"});
+    var iw = W - P.l - P.r, ih = H - P.t - P.b, n = points.length;
+    var max = 1;
+    points.forEach(function(p){
+      cats.forEach(function(c){ max = Math.max(max, (p.values && p.values[c]) || 0); });
+    });
+    var X = function(i){ return n > 1 ? P.l + iw * (i / (n - 1)) : P.l + iw / 2; };
+    var Y = function(v){ return P.t + ih * (1 - v / max); };
+    svg.appendChild(el("line", {class: "axis-base", x1: P.l, x2: P.l + iw, y1: P.t + ih, y2: P.t + ih}));
+    var wi0 = indexOfKey(points, data.window_start), wi1 = indexOfKey(points, data.window_end);
+    if(wi0 > -1 && wi1 > -1){
+      svg.appendChild(el("rect", {x: X(wi0), y: P.t, width: Math.max(X(wi1) - X(wi0), 1), height: ih,
+        fill: band, stroke: accent, "stroke-dasharray": "4 3", "stroke-width": "1", rx: "3"}));
+    }
+    // y max gridline + label so the scale is readable
+    svg.appendChild(el("line", {class: "gridline", x1: P.l, x2: P.l + iw, y1: Y(max), y2: Y(max)}));
+    var maxL = el("text", {x: P.l - 6, y: Y(max) + 3, "text-anchor": "end", fill: tok("--muted"),
+      "font-size": "10", "font-family": "var(--mono)"});
+    maxL.textContent = fmt(max); svg.appendChild(maxL);
+    // one polyline per category
+    cats.forEach(function(c, ci){
+      var col = tok(colors[ci % colors.length]);
+      var dp = "";
+      points.forEach(function(p, i){
+        var v = (p.values && p.values[c]) || 0;
+        dp += (i ? " L" : "M") + X(i) + " " + Y(v);
+      });
+      svg.appendChild(el("path", {d: dp, fill: "none", stroke: col, "stroke-width": "2",
+        "stroke-linejoin": "round", "stroke-linecap": "round"}));
+      var lv = (points[n - 1].values && points[n - 1].values[c]) || 0;
+      svg.appendChild(el("circle", {cx: X(n - 1), cy: Y(lv), r: "3", fill: col}));
+    });
+    // x-axis: earliest and latest keys
+    [0, n - 1].forEach(function(i){
+      if(i < 0) return;
+      var xl = el("text", {x: X(i), y: H - 8, "text-anchor": i === 0 ? "start" : "end",
+        fill: tok("--muted"), "font-size": "10", "font-family": "var(--mono)"});
+      xl.textContent = points[i].key; svg.appendChild(xl);
+    });
+    host.appendChild(svg);
+  }
+
   function drawGroupedH(host, data){
     data = data || {}; var rows = data.rows || []; var cats = data.categories || [];
     if(!rows.length){ host.innerHTML = "<p class=\\"nodata\\">No data</p>"; return; }
@@ -440,6 +487,7 @@ CLIENT_JS = """
     if(c.kind === "bars") drawBars(host, c.data);
     else if(c.kind === "area") drawArea(host, c.data);
     else if(c.kind === "stackedBars") drawStacked(host, c.data);
+    else if(c.kind === "lines") drawLines(host, c.data);
     else if(c.kind === "groupedBarsH") drawGroupedH(host, c.data);
   }
 
@@ -639,7 +687,11 @@ def build_html(report_data: dict) -> str:
     sections = report_data.get("sections") or {}
     products = sections.get("products") or {}
 
-    body_parts = [render_topbar(report_data), render_section(sections.get("unified"))]
+    body_parts = [
+        render_topbar(report_data),
+        render_section(sections.get("unified")),
+        render_section(sections.get("people")),
+    ]
 
     for key in PLATFORM_ORDER:
         product = products.get(key)

--- a/cometx/cli/admin_growth_report.py
+++ b/cometx/cli/admin_growth_report.py
@@ -175,6 +175,24 @@ def _short_api_error(exc):
         if message:
             parts.append(message.group(1))
         return ": ".join(parts)
+    # Fallback (regexes missed): this string can surface in a user-facing
+    # GrowthReportError, so drop everything from the first sensitive marker
+    # onward -- verbose SDK/HTTP errors dump headers, cookies, body, and CSP.
+    lowered = text.lower()
+    cut = len(text)
+    for marker in (
+        "headers:",
+        "header:",
+        "cookie",
+        "body:",
+        "content-security-policy",
+        "csp",
+        "set-cookie",
+    ):
+        idx = lowered.find(marker)
+        if idx != -1:
+            cut = min(cut, idx)
+    text = text[:cut].strip() or "unexpected error"
     return text if len(text) <= 160 else text[:157] + "..."
 
 
@@ -668,6 +686,16 @@ class GrowthReporter:
 
         rate_pts = adoption_rate_series(users, self.units, now_ms, active_window_days)
         if rate_pts:
+            # adoption_rate_series omits em/opik when that capability has no
+            # signal, so build the chart categories/legend from the keys that
+            # are actually present (overall is always there).
+            present = rate_pts[0]["values"].keys()
+            rate_spec = [
+                ("overall", "Overall", "--ok"),
+                ("em", "Experimentation", "--sdk"),
+                ("opik", "Opik", "--accent"),
+            ]
+            rate_spec = [s for s in rate_spec if s[0] in present]
             charts.append(
                 {
                     "id": "chart-people-adoption-rate",
@@ -675,18 +703,12 @@ class GrowthReporter:
                     "title": "Adoption rates",
                     "hint": f"active users / total; active window {self.active_window} · {self._units_adverb()}",
                     "legend": [
-                        {"label": "Overall", "color": "--ok"},
-                        {"label": "Experimentation", "color": "--sdk"},
-                        {"label": "Opik", "color": "--accent"},
+                        {"label": lbl, "color": col} for _, lbl, col in rate_spec
                     ],
                     "data": {
-                        "categories": ["overall", "em", "opik"],
-                        "labels": {
-                            "overall": "Overall",
-                            "em": "Experimentation",
-                            "opik": "Opik",
-                        },
-                        "colors": ["--ok", "--sdk", "--accent"],
+                        "categories": [k for k, _, _ in rate_spec],
+                        "labels": {k: lbl for k, lbl, _ in rate_spec},
+                        "colors": [col for _, _, col in rate_spec],
                         "points": rate_pts,
                         "window_start": None,
                         "window_end": None,
@@ -835,7 +857,7 @@ class GrowthReporter:
         (
             "em_score",
             "EM activity",
-            lambda u: u.experiment_count + u.data_logged_mb,
+            lambda u: (u.experiment_count or 0) + (u.data_logged_mb or 0),
             "EM activity = experiments + data logged (MB); org-wide (chargeback)",
         ),
     ]
@@ -989,10 +1011,14 @@ class GrowthReporter:
         service = split["service"]
         source = split["source"]
 
+        # `source == "heuristic"` means the admin service-accounts fetch was
+        # unavailable / failed / returned an unrecognized shape (a genuine empty
+        # admin response is honored as admin_api). Say so, rather than implying
+        # the admin API responded with zero accounts.
         hint = (
             "Source: service accounts from admin API."
             if source == "admin_api"
-            else "Source: heuristic (regex); admin API returned no service accounts."
+            else "Source: heuristic (regex); admin service-accounts API unavailable."
         )
 
         charts = []

--- a/cometx/cli/admin_growth_report.py
+++ b/cometx/cli/admin_growth_report.py
@@ -32,6 +32,7 @@ from cometx.cli.admin_growth_render import build_html, write_html
 from cometx.cli.admin_growth_users import (
     active_series,
     adoption_stats,
+    bottom_users,
     capability_series,
     parse_users,
     top_users,
@@ -910,6 +911,115 @@ class GrowthReporter:
             "table": table,
         }
 
+    # Workspace-level leaderboard metrics per platform: (metric name, plain
+    # label used in chart titles, e.g. "Top 5 workspaces by {label}").
+    _LEADERBOARD_METRICS = {
+        "em": [("EXPERIMENT_COUNT", "experiments")],
+        "opik": [("SPAN_COUNT", "spans"), ("TRACE_COUNT", "traces")],
+        "mpm": [("PREDICTION_VOLUME", "predictions")],
+    }
+
+    # User-level leaderboard metrics: (top_users/bottom_users key, plain
+    # label, value-extractor matching admin_growth_users._metric_value).
+    _USER_LEADERBOARD_METRICS = [
+        ("opik_span_count", "Opik spans", lambda u: u.opik_span_count),
+        ("em_score", "activity", lambda u: u.experiment_count + u.data_logged_mb),
+    ]
+
+    @staticmethod
+    def _leaderboard_chart(chart_id, title, rows):
+        return {
+            "id": chart_id,
+            "kind": "groupedBarsH",
+            "title": title,
+            "data": {"rows": rows},
+        }
+
+    def _build_leaderboards_section(self, usage, users, ran):
+        """Top-N / bottom-N leaderboards: one per workspace-level metric of
+        each platform that actually ran (Task 5's `ran` map), plus user
+        leaderboards (by `opik_span_count`, by `em_score`) when `users` is
+        non-empty. Bottom-N is active-aware (strictly-positive values only,
+        ascending -- mirrors `bottom_users`). Platforms/metrics with no data
+        are omitted entirely (no empty panels); returns `None` when there is
+        nothing to show at all."""
+        n = self.leaderboard_top_n
+        charts = []
+
+        for platform, metrics in self._LEADERBOARD_METRICS.items():
+            if not ran.get(platform):
+                continue
+            for metric, label in metrics:
+                ws_metrics = [
+                    m
+                    for m in usage
+                    if m.platform == platform
+                    and m.metric == metric
+                    and m.project is None
+                ]
+                if not ws_metrics:
+                    continue
+
+                ranked_desc = sorted(ws_metrics, key=lambda m: m.value, reverse=True)
+                top_rows = [
+                    {"label": m.workspace, "value": m.value}
+                    for m in ranked_desc[:n]
+                ]
+                active_asc = sorted(
+                    (m for m in ws_metrics if m.value > 0), key=lambda m: m.value
+                )
+                bottom_rows = [
+                    {"label": m.workspace, "value": m.value}
+                    for m in active_asc[:n]
+                ]
+
+                slug = f"{platform}-{metric.lower()}"
+                if top_rows:
+                    charts.append(
+                        self._leaderboard_chart(
+                            f"chart-lb-{slug}-top",
+                            f"Top {n} workspaces by {label}",
+                            top_rows,
+                        )
+                    )
+                if bottom_rows:
+                    charts.append(
+                        self._leaderboard_chart(
+                            f"chart-lb-{slug}-bottom",
+                            f"Bottom {n} workspaces by {label}",
+                            bottom_rows,
+                        )
+                    )
+
+        if users:
+            for key, label, value_fn in self._USER_LEADERBOARD_METRICS:
+                top = top_users(users, key, n)
+                if top:
+                    charts.append(
+                        self._leaderboard_chart(
+                            f"chart-lb-user-{key}-top",
+                            f"Top {n} users by {label}",
+                            [{"label": u.username, "value": value_fn(u)} for u in top],
+                        )
+                    )
+                bottom = bottom_users(users, key, n)
+                if bottom:
+                    charts.append(
+                        self._leaderboard_chart(
+                            f"chart-lb-user-{key}-bottom",
+                            f"Bottom {n} users by {label}",
+                            [
+                                {"label": u.username, "value": value_fn(u)}
+                                for u in bottom
+                            ],
+                        )
+                    )
+
+        if not charts:
+            return None
+
+        return {"title": "Leaderboards", "charts": charts}
+
     def _assemble_report_data(
         self, events, usage, ran, workspaces, window, chargeback=None, now_ms=None
     ):
@@ -949,6 +1059,19 @@ class GrowthReporter:
                 people_section = None
             if people_section:
                 sections["people"] = people_section
+
+        try:
+            leaderboard_users = parse_users(chargeback) if chargeback else []
+            leaderboards_section = self._build_leaderboards_section(
+                usage, leaderboard_users, ran
+            )
+        except Exception as exc:
+            print(
+                f"Warning: failed to build leaderboards section; skipping: {exc}"
+            )
+            leaderboards_section = None
+        if leaderboards_section:
+            sections["leaderboards"] = leaderboards_section
 
         return {
             "meta": {

--- a/cometx/cli/admin_growth_report.py
+++ b/cometx/cli/admin_growth_report.py
@@ -501,13 +501,20 @@ class GrowthReporter:
             ws_churn = workspace_churn_series(people_users, self.units, now_ms)
             if ws_churn:
                 # added/deleted as bars, with an overlaid growth-rate line
-                # (added workspaces / cumulative at start of period).
+                # (added workspaces / surviving total at start of period).
+                # The base tracks the *net* surviving total, so it must
+                # subtract deletions as well as add creations each bucket;
+                # otherwise the denominator drifts high and the rate reads low.
                 churn_pts = []
-                prev_total = 0
+                surviving_total = 0
                 for pt in ws_churn:
                     added = pt["values"]["added"]
                     deleted = pt["values"]["deleted"]
-                    rate = round(added / prev_total * 100, 1) if prev_total else 0.0
+                    rate = (
+                        round(added / surviving_total * 100, 1)
+                        if surviving_total
+                        else 0.0
+                    )
                     churn_pts.append(
                         {
                             "key": pt["key"],
@@ -518,7 +525,7 @@ class GrowthReporter:
                             },
                         }
                     )
-                    prev_total += added
+                    surviving_total += added - deleted
                 cb_charts.append(
                     {
                         "id": "chart-unified-workspace-churn",

--- a/cometx/cli/admin_growth_report.py
+++ b/cometx/cli/admin_growth_report.py
@@ -48,7 +48,12 @@ from cometx.cli.admin_growth_users import (
     workspace_churn_series,
     workspace_org_totals,
 )
-from cometx.utils import admin_api_url, fetch_chargeback_report, format_time_key
+from cometx.utils import (
+    InvalidServerURLError,
+    admin_api_url,
+    fetch_chargeback_report,
+    format_time_key,
+)
 
 # `build_html` is re-exported here so the growth-report module is the single
 # import surface (tests + callers import it from here). Declaring it in
@@ -361,10 +366,13 @@ class GrowthReporter:
         print("Fetching chargeback report (admin API)...")
         try:
             chargeback = fetch_chargeback_report(self.api)
-        except ValueError as exc:
-            # A ValueError here is a configuration/URL problem (e.g. a
-            # malformed --host or url_override), not an auth failure. Surface
-            # it as-is rather than asserting the API key isn't admin.
+        except InvalidServerURLError as exc:
+            # A malformed --host / url_override is a configuration problem, not
+            # an auth failure. Surface it as-is rather than asserting the API
+            # key isn't admin. Caught by its own type, not `ValueError`: a
+            # non-JSON 200 (SSO/proxy login page) raises `json.JSONDecodeError`
+            # -- also a `ValueError` -- and belongs in the handler below, which
+            # reports an unusable endpoint rather than a bad URL.
             raise GrowthReportError(
                 f"growth-report could not reach the chargeback endpoint: {exc}"
             ) from exc

--- a/cometx/cli/admin_growth_report.py
+++ b/cometx/cli/admin_growth_report.py
@@ -11,11 +11,13 @@
 #  Copyright (c) 2024 Cometx Development
 #      Team. All rights reserved.
 # ****************************************
-"""cometx admin growth-report — cross-platform use-case growth & rates, per
-workspace/department (Opik + EM + MPM), rendered as a self-contained HTML page.
+"""cometx admin growth-report — org-wide people/usage growth from the admin
+chargeback report, rendered as a self-contained HTML page.
 
-Distinct from `admin usage-report` (experiment counts over time, PDF/Streamlit):
-growth-report tracks cross-platform use-case creation growth and rates.
+Sources exclusively from `/api/admin/chargeback/report` (admin API key
+required): organization overview, users, leaderboards, and a
+personal-vs-service-account split. Distinct from `admin usage-report`
+(experiment counts over time, PDF/Streamlit).
 """
 
 from __future__ import annotations
@@ -112,11 +114,17 @@ def _extract_service_account_names(payload) -> "set[str] | None":
     """Defensively unwrap the `/admin/service-accounts` response into a
     flat set of account names, tolerating several plausible response
     shapes since the exact schema isn't documented in this codebase: a
-    bare list of entries, or a dict wrapping that list under a common
-    container key (`serviceAccounts`, `accounts`, `users`). Each entry may
-    be a plain string, or a dict carrying the name under `name`,
-    `username`, or `email` (mirrors `_extract_licensed_users`'s defensive
-    style in `admin_growth_users.py`).
+    bare list of entries, or a dict wrapping that list under a
+    service-account-specific container key (`serviceAccounts`,
+    `accounts`). Each entry may be a plain string, or a dict carrying the
+    name under `name`, `username`, or `email` (mirrors
+    `_extract_licensed_users`'s defensive style in `admin_growth_users.py`).
+
+    A generic `users` key is deliberately NOT accepted: if the endpoint
+    ever returned the full user roster under it, every user would be
+    classified as a service account and the report would label that
+    inversion authoritative ("admin API"). Better to fail the parse and
+    fall back to the labeled heuristic.
 
     Returns `None` (not an empty set) when the payload cannot be honestly
     parsed as a service-account container -- either because its shape
@@ -131,7 +139,7 @@ def _extract_service_account_names(payload) -> "set[str] | None":
     container = payload
     recognized = isinstance(payload, list)
     if isinstance(payload, dict):
-        for key in ("serviceAccounts", "accounts", "users"):
+        for key in ("serviceAccounts", "accounts"):
             if key in payload:
                 container = payload[key]
                 recognized = isinstance(container, list)
@@ -493,8 +501,6 @@ class GrowthReporter:
                             "labels": {"total": "Total", "active": "Active"},
                             "colors": ["--sdk", "--ok"],
                             "points": ws_active_pts,
-                            "window_start": None,
-                            "window_end": None,
                         },
                     }
                 )
@@ -544,12 +550,15 @@ class GrowthReporter:
                             "points": churn_pts,
                             "bars": ["added", "deleted"],
                             "line": "rate",
-                            "bar_labels": {"added": "Added", "deleted": "Deleted"},
+                            "bar_labels": {
+                                "added": "Added",
+                                "deleted": "Deleted",
+                                "rate": "Growth rate",
+                            },
                             "bar_colors": ["--ok", "--warn"],
                             "line_label": "Growth rate",
                             "line_color": "--accent",
-                            "window_start": None,
-                            "window_end": None,
+                            "line_suffix": "%",
                         },
                     }
                 )
@@ -601,7 +610,7 @@ class GrowthReporter:
             {
                 "label": f"New in {self.window or '7d'} (% of base)",
                 "value": f"{wg['pct']}%",
-                "sub": f"+{wg['new_in']} new",
+                "sub": f"+{wg['new_in']} new (est. from earliest member)",
             },
             {
                 "label": "Active workspaces %",
@@ -686,8 +695,6 @@ class GrowthReporter:
                     "labels": {"total": "Total", "active": "Active"},
                     "colors": ["--sdk", "--ok"],
                     "points": active_pts,
-                    "window_start": None,
-                    "window_end": None,
                 },
             }
         ]
@@ -709,7 +716,10 @@ class GrowthReporter:
                     "id": "chart-people-adoption-rate",
                     "kind": "lines",
                     "title": "Adoption rates",
-                    "hint": f"active users / total; active window {self.active_window} · {self._units_adverb()}",
+                    "hint": (
+                        f"active users / total; active window "
+                        f"{self.active_window} · {self._units_adverb()}"
+                    ),
                     "legend": [
                         {"label": lbl, "color": col} for _, lbl, col in rate_spec
                     ],
@@ -718,8 +728,6 @@ class GrowthReporter:
                         "labels": {k: lbl for k, lbl, _ in rate_spec},
                         "colors": [col for _, _, col in rate_spec],
                         "points": rate_pts,
-                        "window_start": None,
-                        "window_end": None,
                     },
                 }
             )
@@ -731,7 +739,10 @@ class GrowthReporter:
                     "id": "chart-people-capability",
                     "kind": "lines",
                     "title": "Active users by capability",
-                    "hint": f"active window {self.active_window} · {self._units_adverb()}",
+                    "hint": (
+                        f"active window {self.active_window} · "
+                        f"{self._units_adverb()}"
+                    ),
                     "legend": [
                         {"label": "EM", "color": "--sdk"},
                         {"label": "Opik", "color": "--accent"},
@@ -741,8 +752,6 @@ class GrowthReporter:
                         "labels": {"em": "EM", "opik": "Opik"},
                         "colors": ["--sdk", "--accent"],
                         "points": cap_pts,
-                        "window_start": None,
-                        "window_end": None,
                     },
                 }
             )
@@ -771,8 +780,6 @@ class GrowthReporter:
                         },
                         "colors": ["--sdk", "--accent", "--warn"],
                         "points": em_pts,
-                        "window_start": None,
-                        "window_end": None,
                     },
                 }
             )
@@ -799,8 +806,6 @@ class GrowthReporter:
                         },
                         "colors": ["--accent", "--ok"],
                         "points": opik_pts,
-                        "window_start": None,
-                        "window_end": None,
                     },
                 }
             )
@@ -813,8 +818,8 @@ class GrowthReporter:
                     "kind": "lines",
                     "title": "Users added vs. deleted",
                     "hint": (
-                        f"per period · {self._units_adverb()}; deletions reflect soft-deletes "
-                        "still present in the snapshot"
+                        f"per period · {self._units_adverb()}; deletions reflect "
+                        "soft-deletes still present in the snapshot"
                     ),
                     "legend": [
                         {"label": "Added", "color": "--ok"},
@@ -825,8 +830,6 @@ class GrowthReporter:
                         "labels": {"added": "Added", "deleted": "Deleted"},
                         "colors": ["--ok", "--warn"],
                         "points": user_churn,
-                        "window_start": None,
-                        "window_end": None,
                     },
                 }
             )
@@ -839,7 +842,7 @@ class GrowthReporter:
                 [
                     u.username,
                     _num(u.experiment_count),
-                    _num(u.data_logged_mb),
+                    _num(round(u.data_logged_mb)),
                     _num(u.opik_span_count) if u.opik_span_count is not None else "-",
                 ]
                 for u in top
@@ -1066,7 +1069,10 @@ class GrowthReporter:
         the rendered sections."""
         if scope is not None:
             n = scoped_count if scoped_count is not None else len(scope)
-            return f"Scoped to {n} selected workspace(s)"
+            return (
+                f"Scoped to {n} selected workspace(s) "
+                "(per-user totals remain org-wide)"
+            )
         if org_workspaces is not None:
             return (
                 f"Org-wide: {org_workspaces} workspaces, {org_users} users "

--- a/cometx/cli/admin_growth_report.py
+++ b/cometx/cli/admin_growth_report.py
@@ -331,6 +331,8 @@ def generate_growth_report(
     active_window="60d",
     include_users=True,
     leaderboard_top_n=5,
+    exclude_personal=False,
+    personal_pattern=None,
 ):
     reporter = GrowthReporter(
         api,
@@ -341,6 +343,8 @@ def generate_growth_report(
         active_window=active_window,
         include_users=include_users,
         leaderboard_top_n=leaderboard_top_n,
+        exclude_personal=exclude_personal,
+        personal_pattern=personal_pattern,
     )
     report_data = reporter.build(workspaces)  # events + usage -> report_data (C2-C7)
     path = write_growth_html(report_data, output)  # C8
@@ -361,6 +365,8 @@ class GrowthReporter:
         active_window="60d",
         include_users=True,
         leaderboard_top_n=5,
+        exclude_personal=False,
+        personal_pattern=None,
     ):
         self.api = api
         self.window = window
@@ -370,6 +376,9 @@ class GrowthReporter:
         self.active_window = active_window
         self.include_users = include_users
         self.leaderboard_top_n = leaderboard_top_n
+        self.exclude_personal = exclude_personal
+        self.personal_pattern = personal_pattern
+        self._warned_no_personal_pattern = False
 
     def build(self, workspaces):
         """Resolve window/platforms/workspaces, run the selected collectors,
@@ -440,9 +449,43 @@ class GrowthReporter:
         resolved = (
             list(workspaces) if workspaces else list(self.api.get_workspaces() or [])
         )
+        resolved = self._filter_personal(resolved)
         if self.limit is not None:
             resolved = resolved[: self.limit]
         return resolved
+
+    def _filter_personal(self, workspaces):
+        """Drop workspaces matching `self.personal_pattern` when
+        `self.exclude_personal` is set (Task 9). A no-op unless BOTH the
+        flag is on AND a pattern was supplied -- an on flag with no pattern
+        can't identify anything to drop, so it's a no-op too, with a
+        once-per-reporter warning since that combination is almost
+        certainly a user mistake (they meant to also pass
+        `--personal-pattern`). An invalid regex degrades the same way
+        (warn once, return unchanged) rather than crashing the whole run.
+        """
+        if not self.exclude_personal:
+            return list(workspaces)
+        if not self.personal_pattern:
+            if not self._warned_no_personal_pattern:
+                print(
+                    "Warning: --exclude-personal has no effect without "
+                    "--personal-pattern; skipping personal-workspace exclusion"
+                )
+                self._warned_no_personal_pattern = True
+            return list(workspaces)
+        try:
+            pattern = re.compile(self.personal_pattern)
+        except re.error as exc:
+            if not self._warned_no_personal_pattern:
+                print(
+                    f"Warning: invalid --personal-pattern "
+                    f"{self.personal_pattern!r} ({exc}); skipping "
+                    "personal-workspace exclusion"
+                )
+                self._warned_no_personal_pattern = True
+            return list(workspaces)
+        return [ws for ws in workspaces if not pattern.search(ws)]
 
     _COLLECTOR_METHODS = {
         "em": "_collect_em",

--- a/cometx/cli/admin_growth_report.py
+++ b/cometx/cli/admin_growth_report.py
@@ -25,6 +25,7 @@ import datetime
 import os
 import re
 from collections import defaultdict
+from urllib.parse import urlparse
 
 from tqdm import tqdm
 
@@ -34,6 +35,7 @@ from cometx.cli.admin_growth_users import (
     adoption_stats,
     bottom_users,
     capability_series,
+    classify_accounts,
     parse_users,
     top_users,
 )
@@ -129,6 +131,56 @@ def _num(value):
     if isinstance(value, float) and value.is_integer():
         return int(value)
     return value
+
+
+def _extract_service_account_names(payload) -> "set[str]":
+    """Defensively unwrap the `/admin/service-accounts` response into a
+    flat set of account names, tolerating several plausible response
+    shapes since the exact schema isn't documented in this codebase: a
+    bare list of entries, or a dict wrapping that list under a common
+    container key (`serviceAccounts`, `accounts`, `users`). Each entry may
+    be a plain string, or a dict carrying the name under `name`,
+    `username`, or `email` (mirrors `_extract_licensed_users`'s defensive
+    style in `admin_growth_users.py`)."""
+    if isinstance(payload, dict):
+        for key in ("serviceAccounts", "accounts", "users"):
+            if key in payload:
+                payload = payload[key]
+                break
+    if not isinstance(payload, list):
+        return set()
+
+    names = set()
+    for entry in payload:
+        if isinstance(entry, str):
+            names.add(entry)
+        elif isinstance(entry, dict):
+            name = entry.get("name") or entry.get("username") or entry.get("email")
+            if name:
+                names.add(name)
+    return names
+
+
+def _fetch_service_accounts(api) -> "set[str] | None":
+    """Fetch the authoritative set of service-account names from the admin
+    `/admin/service-accounts` endpoint (same request shape as
+    `fetch_chargeback_report` in `cometx.utils`), for `classify_accounts`'s
+    admin_api path. Returns `None` on ANY failure -- endpoint disabled,
+    403/404, network error, unexpected response shape -- so callers
+    degrade to the labeled regex heuristic instead of crashing."""
+    try:
+        parsed = urlparse(api.config["comet.url_override"])
+        base = "%s://%s" % (parsed.scheme, parsed.netloc)
+        while base.endswith("/"):
+            base = base[:-1]
+        url = base + "/api/admin/service-accounts"
+        response = api._client.get(
+            url, headers={"Authorization": api.api_key}, params={}
+        )
+        payload = response.json()
+        return _extract_service_account_names(payload)
+    except Exception:
+        return None
 
 
 def _as_float(value):
@@ -1020,6 +1072,65 @@ class GrowthReporter:
 
         return {"title": "Leaderboards", "charts": charts}
 
+    # Personal-vs-service-account metrics, one groupedBarsH chart each:
+    # (classify_accounts totals key, plain label for the chart title).
+    _PERSONAL_VS_SERVICE_METRICS = [
+        ("experiments", "experiments"),
+        ("data", "data logged (MB)"),
+        ("spans", "Opik spans"),
+    ]
+
+    def _build_personal_vs_service_section(self, users, service_account_names):
+        """Personal-vs-service-account split (Task 8): one `groupedBarsH`
+        chart per metric (experiments / data / spans), each showing
+        Personal vs. Service totals via `classify_accounts`. A metric's
+        chart is omitted when both buckets are zero for it (nothing to
+        show). Returns `None` when `users` is empty or every metric is
+        all-zero (degrade, never render an empty section)."""
+        if not users:
+            return None
+
+        split = classify_accounts(users, service_account_names)
+        personal = split["personal"]
+        service = split["service"]
+        source = split["source"]
+
+        hint = (
+            "Source: service accounts from admin API."
+            if source == "admin_api"
+            else "Source: heuristic (regex); admin API service-account data unavailable."
+        )
+
+        charts = []
+        for key, label in self._PERSONAL_VS_SERVICE_METRICS:
+            personal_value = personal.get(key, 0)
+            service_value = service.get(key, 0)
+            if not personal_value and not service_value:
+                continue
+            charts.append(
+                {
+                    "id": f"chart-personal-vs-service-{key}",
+                    "kind": "groupedBarsH",
+                    "title": f"Personal vs. service accounts: {label}",
+                    "hint": hint,
+                    "data": {
+                        "rows": [
+                            {"label": "Personal", "value": _num(personal_value)},
+                            {"label": "Service", "value": _num(service_value)},
+                        ]
+                    },
+                }
+            )
+
+        if not charts:
+            return None
+
+        return {
+            "title": "Personal vs. service accounts",
+            "charts": charts,
+            "hint": hint,
+        }
+
     def _assemble_report_data(
         self, events, usage, ran, workspaces, window, chargeback=None, now_ms=None
     ):
@@ -1072,6 +1183,21 @@ class GrowthReporter:
             leaderboards_section = None
         if leaderboards_section:
             sections["leaderboards"] = leaderboards_section
+
+        try:
+            personal_vs_service_section = None
+            if leaderboard_users:
+                service_account_names = _fetch_service_accounts(self.api)
+                personal_vs_service_section = self._build_personal_vs_service_section(
+                    leaderboard_users, service_account_names
+                )
+        except Exception as exc:
+            print(
+                f"Warning: failed to build personal-vs-service section; skipping: {exc}"
+            )
+            personal_vs_service_section = None
+        if personal_vs_service_section:
+            sections["personal_vs_service"] = personal_vs_service_section
 
         return {
             "meta": {

--- a/cometx/cli/admin_growth_report.py
+++ b/cometx/cli/admin_growth_report.py
@@ -1192,7 +1192,6 @@ class GrowthReporter:
         return {
             "title": "Personal vs. service accounts",
             "charts": charts,
-            "hint": hint,
         }
 
     def _assemble_report_data(
@@ -1235,6 +1234,7 @@ class GrowthReporter:
             if people_section:
                 sections["people"] = people_section
 
+        leaderboard_users = []
         try:
             leaderboard_users = parse_users(chargeback) if chargeback else []
             leaderboards_section = self._build_leaderboards_section(

--- a/cometx/cli/admin_growth_report.py
+++ b/cometx/cli/admin_growth_report.py
@@ -403,7 +403,9 @@ class GrowthReporter:
                 print("Collecting users/people data (chargeback report)...")
                 chargeback = fetch_chargeback_report(self.api)
             except Exception as exc:
-                print(f"Warning: failed to fetch chargeback report; skipping people layer: {exc}")
+                print(
+                    f"Warning: failed to fetch chargeback report; skipping people layer: {exc}"
+                )
                 chargeback = None
 
         print("Building report...")
@@ -1078,15 +1080,13 @@ class GrowthReporter:
 
                 ranked_desc = sorted(ws_metrics, key=lambda m: m.value, reverse=True)
                 top_rows = [
-                    {"label": m.workspace, "value": m.value}
-                    for m in ranked_desc[:n]
+                    {"label": m.workspace, "value": m.value} for m in ranked_desc[:n]
                 ]
                 active_asc = sorted(
                     (m for m in ws_metrics if m.value > 0), key=lambda m: m.value
                 )
                 bottom_rows = [
-                    {"label": m.workspace, "value": m.value}
-                    for m in active_asc[:n]
+                    {"label": m.workspace, "value": m.value} for m in active_asc[:n]
                 ]
 
                 slug = f"{platform}-{metric.lower()}"
@@ -1241,9 +1241,7 @@ class GrowthReporter:
                 usage, leaderboard_users, ran
             )
         except Exception as exc:
-            print(
-                f"Warning: failed to build leaderboards section; skipping: {exc}"
-            )
+            print(f"Warning: failed to build leaderboards section; skipping: {exc}")
             leaderboards_section = None
         if leaderboards_section:
             sections["leaderboards"] = leaderboards_section

--- a/cometx/cli/admin_growth_report.py
+++ b/cometx/cli/admin_growth_report.py
@@ -29,7 +29,13 @@ from collections import defaultdict
 from tqdm import tqdm
 
 from cometx.cli.admin_growth_render import build_html, write_html
-from cometx.cli.admin_growth_users import adoption_stats, parse_users, top_users
+from cometx.cli.admin_growth_users import (
+    active_series,
+    adoption_stats,
+    capability_series,
+    parse_users,
+    top_users,
+)
 from cometx.utils import fetch_chargeback_report, format_time_key, get_next_time_key
 
 # `build_html` is re-exported here so the growth-report module is the single
@@ -802,9 +808,10 @@ class GrowthReporter:
 
     def _build_people_section(self, chargeback, now_ms):
         """Users/adoption section, derived from the chargeback report (Task
-        4 helpers). Minimal-but-real for this task: KPIs (Total / Active /
-        Adoption %) plus a single-bucket `lines` chart of active vs. total;
-        a richer over-time series is Task 6."""
+        4 helpers). KPIs (Total / Active / Adoption %) plus real over-time
+        `lines` charts: active-vs-total (Task 6's `active_series`), and,
+        when at least one user has an EM/Opik capability timestamp, a
+        per-capability active-users chart (`capability_series`)."""
         now = _ms_to_utc(now_ms)
         active_window_days = self._active_window_days(now)
 
@@ -820,34 +827,66 @@ class GrowthReporter:
             {"label": "Adoption %", "value": f"{stats['adoption_pct']}%"},
         ]
 
-        bucket_key = format_time_key(now, self.units)
-        categories = ["active", "total"]
-        chart = {
-            "id": "chart-people-active-total",
-            "kind": "lines",
-            "title": "Active vs. total users",
-            "hint": f"current period · active window {self.active_window}",
-            "legend": [
-                {"label": "Active", "color": "--ok"},
-                {"label": "Total", "color": "--sdk"},
-            ],
-            "data": {
-                "categories": categories,
-                "labels": {"active": "Active", "total": "Total"},
-                "colors": ["--ok", "--sdk"],
-                "points": [
-                    {
-                        "key": bucket_key,
-                        "values": {
-                            "active": stats["active"],
-                            "total": stats["total"],
-                        },
-                    }
+        active_pts = active_series(users, self.units, now_ms, active_window_days)
+        if active_pts:
+            window_start = active_pts[0]["key"]
+            window_end = active_pts[-1]["key"]
+            points = active_pts
+        else:
+            # No user has a known created_at to bucket from -- degrade to a
+            # single current-period point rather than an empty chart.
+            bucket_key = format_time_key(now, self.units)
+            window_start = window_end = bucket_key
+            points = [
+                {
+                    "key": bucket_key,
+                    "values": {"total": stats["total"], "active": stats["active"]},
+                }
+            ]
+
+        charts = [
+            {
+                "id": "chart-people-active-total",
+                "kind": "lines",
+                "title": "Active vs. total users",
+                "hint": f"active window {self.active_window} · {self.units}ly",
+                "legend": [
+                    {"label": "Total", "color": "--sdk"},
+                    {"label": "Active", "color": "--ok"},
                 ],
-                "window_start": bucket_key,
-                "window_end": bucket_key,
-            },
-        }
+                "data": {
+                    "categories": ["total", "active"],
+                    "labels": {"total": "Total", "active": "Active"},
+                    "colors": ["--sdk", "--ok"],
+                    "points": points,
+                    "window_start": window_start,
+                    "window_end": window_end,
+                },
+            }
+        ]
+
+        cap_pts = capability_series(users, self.units, now_ms, active_window_days)
+        if cap_pts:
+            charts.append(
+                {
+                    "id": "chart-people-capability",
+                    "kind": "lines",
+                    "title": "Active users by capability",
+                    "hint": f"active window {self.active_window} · {self.units}ly",
+                    "legend": [
+                        {"label": "EM", "color": "--sdk"},
+                        {"label": "Opik", "color": "--accent"},
+                    ],
+                    "data": {
+                        "categories": ["em", "opik"],
+                        "labels": {"em": "EM", "opik": "Opik"},
+                        "colors": ["--sdk", "--accent"],
+                        "points": cap_pts,
+                        "window_start": cap_pts[0]["key"],
+                        "window_end": cap_pts[-1]["key"],
+                    },
+                }
+            )
 
         top = top_users(users, "em_score", self.leaderboard_top_n)
         table = {
@@ -867,7 +906,7 @@ class GrowthReporter:
         return {
             "title": "Users & adoption",
             "kpis": kpis,
-            "charts": [chart],
+            "charts": charts,
             "table": table,
         }
 

--- a/cometx/cli/admin_growth_report.py
+++ b/cometx/cli/admin_growth_report.py
@@ -53,6 +53,7 @@ from cometx.utils import (
     admin_api_url,
     fetch_chargeback_report,
     format_time_key,
+    redact_url_userinfo,
 )
 
 # `build_html` is re-exported here so the growth-report module is the single
@@ -242,6 +243,9 @@ def _short_api_error(exc):
         if idx != -1:
             cut = min(cut, idx)
     text = text[:cut].strip() or "unexpected error"
+    # SDK/HTTP exceptions routinely quote the request URL, which may carry
+    # userinfo from the configured base -- redact before this reaches a user.
+    text = redact_url_userinfo(text)
     return text if len(text) <= 160 else text[:157] + "..."
 
 

--- a/cometx/cli/admin_growth_report.py
+++ b/cometx/cli/admin_growth_report.py
@@ -133,7 +133,7 @@ def _num(value):
     return value
 
 
-def _extract_service_account_names(payload) -> "set[str]":
+def _extract_service_account_names(payload) -> "set[str] | None":
     """Defensively unwrap the `/admin/service-accounts` response into a
     flat set of account names, tolerating several plausible response
     shapes since the exact schema isn't documented in this codebase: a
@@ -141,24 +141,42 @@ def _extract_service_account_names(payload) -> "set[str]":
     container key (`serviceAccounts`, `accounts`, `users`). Each entry may
     be a plain string, or a dict carrying the name under `name`,
     `username`, or `email` (mirrors `_extract_licensed_users`'s defensive
-    style in `admin_growth_users.py`)."""
+    style in `admin_growth_users.py`).
+
+    Returns `None` (not an empty set) when the payload cannot be honestly
+    parsed as a service-account container -- either because its shape
+    isn't recognized at all, or because a recognized, non-empty container
+    yielded zero extractable names. An empty set is returned only for a
+    recognized container that is genuinely empty (e.g. `[]` or
+    `{"serviceAccounts": []}`), which is a real "zero service accounts"
+    answer, not a parse failure. Distinguishing these two lets callers
+    (`_fetch_service_accounts`) fall back to the labeled regex heuristic
+    on a parse failure instead of silently reporting zero via the
+    (misleading) admin_api source."""
+    container = payload
+    recognized = isinstance(payload, list)
     if isinstance(payload, dict):
         for key in ("serviceAccounts", "accounts", "users"):
             if key in payload:
-                payload = payload[key]
+                container = payload[key]
+                recognized = isinstance(container, list)
                 break
-    if not isinstance(payload, list):
+
+    if not recognized:
+        return None
+    if not container:
         return set()
 
     names = set()
-    for entry in payload:
+    for entry in container:
         if isinstance(entry, str):
             names.add(entry)
         elif isinstance(entry, dict):
             name = entry.get("name") or entry.get("username") or entry.get("email")
             if name:
                 names.add(name)
-    return names
+
+    return names or None
 
 
 def _fetch_service_accounts(api) -> "set[str] | None":
@@ -166,8 +184,11 @@ def _fetch_service_accounts(api) -> "set[str] | None":
     `/admin/service-accounts` endpoint (same request shape as
     `fetch_chargeback_report` in `cometx.utils`), for `classify_accounts`'s
     admin_api path. Returns `None` on ANY failure -- endpoint disabled,
-    403/404, network error, unexpected response shape -- so callers
-    degrade to the labeled regex heuristic instead of crashing."""
+    403/404, network error, unexpected response shape, or a successful
+    response that could not be honestly parsed into any names (see
+    `_extract_service_account_names`) -- so callers degrade to the
+    labeled regex heuristic instead of crashing or silently reporting a
+    zero split under the admin_api label."""
     try:
         parsed = urlparse(api.config["comet.url_override"])
         base = "%s://%s" % (parsed.scheme, parsed.netloc)

--- a/cometx/cli/admin_growth_report.py
+++ b/cometx/cli/admin_growth_report.py
@@ -900,7 +900,14 @@ class GrowthReporter:
 
         sections = {"unified": unified_section, "products": products}
         if chargeback:
-            people_section = self._build_people_section(chargeback, now_ms)
+            try:
+                people_section = self._build_people_section(chargeback, now_ms)
+            except Exception as exc:
+                print(
+                    f"Warning: failed to build people section from chargeback data; "
+                    f"skipping people layer: {exc}"
+                )
+                people_section = None
             if people_section:
                 sections["people"] = people_section
 

--- a/cometx/cli/admin_growth_report.py
+++ b/cometx/cli/admin_growth_report.py
@@ -29,7 +29,8 @@ from collections import defaultdict
 from tqdm import tqdm
 
 from cometx.cli.admin_growth_render import build_html, write_html
-from cometx.utils import format_time_key, get_next_time_key
+from cometx.cli.admin_growth_users import adoption_stats, parse_users, top_users
+from cometx.utils import fetch_chargeback_report, format_time_key, get_next_time_key
 
 # `build_html` is re-exported here so the growth-report module is the single
 # import surface (tests + callers import it from here). Declaring it in
@@ -247,9 +248,19 @@ def generate_growth_report(
     output="growth_report.html",
     no_open=False,
     limit=None,
+    active_window="60d",
+    include_users=True,
+    leaderboard_top_n=5,
 ):
     reporter = GrowthReporter(
-        api, window=window, units=units, platforms=platforms, limit=limit
+        api,
+        window=window,
+        units=units,
+        platforms=platforms,
+        limit=limit,
+        active_window=active_window,
+        include_users=include_users,
+        leaderboard_top_n=leaderboard_top_n,
     )
     report_data = reporter.build(workspaces)  # events + usage -> report_data (C2-C7)
     path = write_growth_html(report_data, output)  # C8
@@ -259,12 +270,26 @@ def generate_growth_report(
 
 
 class GrowthReporter:
-    def __init__(self, api, *, window, units, platforms, limit=None):
+    def __init__(
+        self,
+        api,
+        *,
+        window,
+        units,
+        platforms,
+        limit=None,
+        active_window="60d",
+        include_users=True,
+        leaderboard_top_n=5,
+    ):
         self.api = api
         self.window = window
         self.units = units
         self.platforms = platforms
         self.limit = limit
+        self.active_window = active_window
+        self.include_users = include_users
+        self.leaderboard_top_n = leaderboard_top_n
 
     def build(self, workspaces):
         """Resolve window/platforms/workspaces, run the selected collectors,
@@ -282,10 +307,21 @@ class GrowthReporter:
             f"{len(resolved_workspaces)} workspace(s)..."
         )
         events, usage, ran = self._collect_selected(platforms, resolved_workspaces)
+
+        chargeback = None
+        if self.include_users and platforms:
+            try:
+                print("Collecting users/people data (chargeback report)...")
+                chargeback = fetch_chargeback_report(self.api)
+            except Exception as exc:
+                print(f"Warning: failed to fetch chargeback report; skipping people layer: {exc}")
+                chargeback = None
+
         print("Building report...")
 
+        now_ms = int(now.timestamp() * 1000)
         return self._assemble_report_data(
-            events, usage, ran, resolved_workspaces, window
+            events, usage, ran, resolved_workspaces, window, chargeback, now_ms
         )
 
     def _now(self):
@@ -757,7 +793,87 @@ class GrowthReporter:
             "adoption": self._build_adoption_section(platform, usage, window),
         }
 
-    def _assemble_report_data(self, events, usage, ran, workspaces, window):
+    def _active_window_days(self, now):
+        """Resolve `self.active_window` (e.g. "60d") into an integer day
+        count, via the shared `parse_window` parser (same spec grammar as
+        `--window`)."""
+        active_window = parse_window(self.active_window, now, self.units)
+        return max(1, (active_window.end - active_window.start).days)
+
+    def _build_people_section(self, chargeback, now_ms):
+        """Users/adoption section, derived from the chargeback report (Task
+        4 helpers). Minimal-but-real for this task: KPIs (Total / Active /
+        Adoption %) plus a single-bucket `lines` chart of active vs. total;
+        a richer over-time series is Task 6."""
+        now = _ms_to_utc(now_ms)
+        active_window_days = self._active_window_days(now)
+
+        users = parse_users(chargeback)
+        stats = adoption_stats(users, now_ms, active_window_days)
+
+        kpis = [
+            {"label": "Total", "value": stats["total"]},
+            {
+                "label": f"Active ({self.active_window})",
+                "value": stats["active"],
+            },
+            {"label": "Adoption %", "value": f"{stats['adoption_pct']}%"},
+        ]
+
+        bucket_key = format_time_key(now, self.units)
+        categories = ["active", "total"]
+        chart = {
+            "id": "chart-people-active-total",
+            "kind": "lines",
+            "title": "Active vs. total users",
+            "hint": f"current period · active window {self.active_window}",
+            "legend": [
+                {"label": "Active", "color": "--ok"},
+                {"label": "Total", "color": "--sdk"},
+            ],
+            "data": {
+                "categories": categories,
+                "labels": {"active": "Active", "total": "Total"},
+                "colors": ["--ok", "--sdk"],
+                "points": [
+                    {
+                        "key": bucket_key,
+                        "values": {
+                            "active": stats["active"],
+                            "total": stats["total"],
+                        },
+                    }
+                ],
+                "window_start": bucket_key,
+                "window_end": bucket_key,
+            },
+        }
+
+        top = top_users(users, "em_score", self.leaderboard_top_n)
+        table = {
+            "title": f"Top {self.leaderboard_top_n} users by activity",
+            "headers": ["User", "Experiments", "Data logged (MB)", "Opik spans"],
+            "rows": [
+                [
+                    u.username,
+                    _num(u.experiment_count),
+                    _num(u.data_logged_mb),
+                    _num(u.opik_span_count) if u.opik_span_count is not None else "-",
+                ]
+                for u in top
+            ],
+        }
+
+        return {
+            "title": "Users & adoption",
+            "kpis": kpis,
+            "charts": [chart],
+            "table": table,
+        }
+
+    def _assemble_report_data(
+        self, events, usage, ran, workspaces, window, chargeback=None, now_ms=None
+    ):
         workspaces_count = len(workspaces)
         unified_section = self._build_unified_section(events, window, workspaces_count)
         count_before_unified = sum(
@@ -782,6 +898,12 @@ class GrowthReporter:
                 workspaces_count,
             )
 
+        sections = {"unified": unified_section, "products": products}
+        if chargeback:
+            people_section = self._build_people_section(chargeback, now_ms)
+            if people_section:
+                sections["people"] = people_section
+
         return {
             "meta": {
                 "title": "Comet growth report",
@@ -790,7 +912,7 @@ class GrowthReporter:
             },
             "window": self._build_window_block(window, count_before_unified),
             "collectors": ran,
-            "sections": {"unified": unified_section, "products": products},
+            "sections": sections,
         }
 
     def _workspace_usage_metric(self, platform, metric, workspace, value, counts):

--- a/cometx/cli/admin_growth_report.py
+++ b/cometx/cli/admin_growth_report.py
@@ -28,6 +28,7 @@ from urllib.parse import urlparse
 
 from cometx.cli.admin_growth_render import build_html, write_html
 from cometx.cli.admin_growth_users import (
+    _extract_licensed_users,
     active_series,
     adoption_rate_series,
     adoption_stats,
@@ -178,20 +179,11 @@ def _short_api_error(exc):
 
 
 def _chargeback_licensed_users(chargeback):
-    """Return the raw licensed-user records from a chargeback dict, tolerating
-    the same container shapes as `admin_growth_users.parse_users` (dict with
-    `licensedUsers`, dict with `report`, or a bare list)."""
-    users_field = (chargeback or {}).get("users")
-    if isinstance(users_field, dict):
-        if "licensedUsers" in users_field:
-            return users_field.get("licensedUsers") or []
-        report = users_field.get("report")
-        if report is not None:
-            return _chargeback_licensed_users({"users": report})
-        return []
-    if isinstance(users_field, list):
-        return users_field
-    return []
+    """Raw licensed-user records from a chargeback dict. Delegates to the single
+    shared unwrapper `admin_growth_users._extract_licensed_users` so the
+    `licensedUsers` / `report` / bare-list handling lives in exactly one place
+    (used by both `parse_users` and `_scope_chargeback`)."""
+    return _extract_licensed_users((chargeback or {}).get("users"))
 
 
 def _scope_chargeback(chargeback, workspace_names):
@@ -322,6 +314,16 @@ class GrowthReporter:
     def _now(self):
         return datetime.datetime.now(datetime.timezone.utc)
 
+    def _units_adverb(self):
+        """Adverb form of the chart bucket unit for hint text, so `day` reads
+        `daily` rather than the `{units}ly` -> `dayly` typo."""
+        return {
+            "hour": "hourly",
+            "day": "daily",
+            "week": "weekly",
+            "month": "monthly",
+        }.get(self.units, self.units + "ly")
+
     def _personal_pattern_compiled(self):
         """Compiled --personal-pattern regex, or None (with a once-per-reporter
         warning) when the flag is off, no pattern was given, or the pattern is
@@ -436,7 +438,11 @@ class GrowthReporter:
         cb_charts = []
         if people_users:
             ws_active_pts = workspace_active_series(
-                people_users, self.units, now_ms, active_window_days
+                people_users,
+                self.units,
+                now_ms,
+                active_window_days,
+                all_workspaces={w.name for w in (ws_records or [])},
             )
             if ws_active_pts:
                 cb_charts.append(
@@ -489,7 +495,7 @@ class GrowthReporter:
                         "kind": "barsLine",
                         "title": "Workspaces added vs. deleted",
                         "hint": (
-                            f"org-wide (chargeback) · {self.units}ly · "
+                            f"org-wide (chargeback) · {self._units_adverb()} · "
                             "deletion is a proxy"
                         ),
                         "legend": [
@@ -644,7 +650,7 @@ class GrowthReporter:
                 "id": "chart-people-active-total",
                 "kind": "lines",
                 "title": "Active vs. total users",
-                "hint": f"active window {self.active_window} · {self.units}ly",
+                "hint": f"active window {self.active_window} · {self._units_adverb()}",
                 "legend": [
                     {"label": "Total", "color": "--sdk"},
                     {"label": "Active", "color": "--ok"},
@@ -667,7 +673,7 @@ class GrowthReporter:
                     "id": "chart-people-adoption-rate",
                     "kind": "lines",
                     "title": "Adoption rates",
-                    "hint": f"active users / total; active window {self.active_window} · {self.units}ly",
+                    "hint": f"active users / total; active window {self.active_window} · {self._units_adverb()}",
                     "legend": [
                         {"label": "Overall", "color": "--ok"},
                         {"label": "Experimentation", "color": "--sdk"},
@@ -695,7 +701,7 @@ class GrowthReporter:
                     "id": "chart-people-capability",
                     "kind": "lines",
                     "title": "Active users by capability",
-                    "hint": f"active window {self.active_window} · {self.units}ly",
+                    "hint": f"active window {self.active_window} · {self._units_adverb()}",
                     "legend": [
                         {"label": "EM", "color": "--sdk"},
                         {"label": "Opik", "color": "--accent"},
@@ -711,7 +717,7 @@ class GrowthReporter:
                 }
             )
 
-        window_hint = f"active window {self.active_window} · {self.units}ly"
+        window_hint = f"active window {self.active_window} · {self._units_adverb()}"
 
         em_pts = em_user_breakdown_series(users, self.units, now_ms, active_window_days)
         if em_pts:
@@ -777,7 +783,7 @@ class GrowthReporter:
                     "kind": "lines",
                     "title": "Users added vs. deleted",
                     "hint": (
-                        f"per period · {self.units}ly; deletions reflect soft-deletes "
+                        f"per period · {self._units_adverb()}; deletions reflect soft-deletes "
                         "still present in the snapshot"
                     ),
                     "legend": [
@@ -1019,10 +1025,14 @@ class GrowthReporter:
         }
 
     @staticmethod
-    def _scope_label(scope, org_workspaces, org_users):
-        """One-line scope descriptor for the report header."""
+    def _scope_label(scope, org_workspaces, org_users, scoped_count=None):
+        """One-line scope descriptor for the report header. When scoped, the
+        count reflects the workspaces actually present after scoping/filtering
+        (`scoped_count`), not the raw requested arg list, so the badge matches
+        the rendered sections."""
         if scope is not None:
-            return f"Scoped to {len(scope)} selected workspace(s)"
+            n = scoped_count if scoped_count is not None else len(scope)
+            return f"Scoped to {n} selected workspace(s)"
         if org_workspaces is not None:
             return (
                 f"Org-wide: {org_workspaces} workspaces, {org_users} users "
@@ -1093,12 +1103,13 @@ class GrowthReporter:
             personal_vs_service_section = None
             if people_users:
                 service_account_names = _fetch_service_accounts(self.api)
-                # Admin endpoint first; fall back to the regex heuristic when it
-                # is unavailable (None) OR returns an empty set (no service
-                # accounts listed) -- an empty admin list is uninformative and
-                # would otherwise mislabel every account as personal.
-                if not service_account_names:
-                    service_account_names = None
+                # `_fetch_service_accounts` already returns None on any failure
+                # (endpoint unavailable / unrecognized shape) and a set on
+                # success. An empty set is the authoritative "admin API returned
+                # zero service accounts" answer, which classify_accounts honors
+                # as the admin_api source -- do NOT coerce it to None (that would
+                # discard the authoritative answer and fall back to the regex
+                # heuristic).
                 personal_vs_service_section = self._build_personal_vs_service_section(
                     people_users, service_account_names
                 )
@@ -1115,7 +1126,9 @@ class GrowthReporter:
                 "title": "Comet growth report",
                 "generated": window.end.isoformat(),
                 "source": "Comet Admin API (chargeback)",
-                "scope": self._scope_label(scope, org_workspaces, org_users),
+                "scope": self._scope_label(
+                    scope, org_workspaces, org_users, scoped_count=len(ws_records)
+                ),
             },
             "window": self._build_window_block(window, 0),
             "sections": sections,

--- a/cometx/cli/admin_growth_report.py
+++ b/cometx/cli/admin_growth_report.py
@@ -26,7 +26,6 @@ import dataclasses
 import datetime
 import os
 import re
-from urllib.parse import urlparse
 
 from cometx.cli.admin_growth_render import build_html, write_html
 from cometx.cli.admin_growth_users import (
@@ -49,7 +48,7 @@ from cometx.cli.admin_growth_users import (
     workspace_churn_series,
     workspace_org_totals,
 )
-from cometx.utils import fetch_chargeback_report, format_time_key
+from cometx.utils import admin_api_url, fetch_chargeback_report, format_time_key
 
 # `build_html` is re-exported here so the growth-report module is the single
 # import surface (tests + callers import it from here). Declaring it in
@@ -88,6 +87,19 @@ def _num(value):
     are naturally integers but arrive as floats from the collectors."""
     if isinstance(value, float) and value.is_integer():
         return int(value)
+    return value
+
+
+def _lb_value(value):
+    """Normalize a leaderboard bar value the same way workspace rows are
+    rendered: round a fractional metric (e.g. `em_score`, which folds in
+    `data_logged_mb`) to a clean integer via `_num(round(...))`. Passes
+    `None` through unchanged so a metric a user lacks stays absent rather
+    than becoming 0."""
+    if value is None:
+        return None
+    if isinstance(value, float):
+        return _num(round(value))
     return value
 
 
@@ -173,11 +185,12 @@ def _fetch_service_accounts(api) -> "set[str] | None":
     labeled regex heuristic instead of crashing or silently reporting a
     zero split under the admin_api label."""
     try:
-        parsed = urlparse(api.config["comet.url_override"])
-        base = "%s://%s" % (parsed.scheme, parsed.netloc)
-        while base.endswith("/"):
-            base = base[:-1]
-        url = base + "/api/admin/service-accounts"
+        # Reuse the shared validated URL builder so this endpoint honors the
+        # same scheme/host/path-prefix handling as fetch_chargeback_report
+        # (the two admin endpoints were previously built inconsistently).
+        url = admin_api_url(
+            api.config["comet.url_override"], "/api/admin/service-accounts"
+        )
         response = api._client.get(
             url, headers={"Authorization": api.api_key}, params={}
         )
@@ -207,13 +220,17 @@ def _short_api_error(exc):
     # onward -- verbose SDK/HTTP errors dump headers, cookies, body, and CSP.
     lowered = text.lower()
     cut = len(text)
+    # NB: markers are matched as substrings anywhere in the text, so each must
+    # be specific enough not to fire on an incidental hostname/message word.
+    # "content-security-policy" already covers the CSP header; a bare "csp"
+    # (3 chars) would truncate errors that merely happen to contain those
+    # letters, so it is intentionally not listed.
     for marker in (
         "headers:",
         "header:",
         "cookie",
         "body:",
         "content-security-policy",
-        "csp",
         "set-cookie",
     ):
         idx = lowered.find(marker)
@@ -344,6 +361,13 @@ class GrowthReporter:
         print("Fetching chargeback report (admin API)...")
         try:
             chargeback = fetch_chargeback_report(self.api)
+        except ValueError as exc:
+            # A ValueError here is a configuration/URL problem (e.g. a
+            # malformed --host or url_override), not an auth failure. Surface
+            # it as-is rather than asserting the API key isn't admin.
+            raise GrowthReportError(
+                f"growth-report could not reach the chargeback endpoint: {exc}"
+            ) from exc
         except Exception as exc:
             raise GrowthReportError(
                 "growth-report requires an admin API key: the chargeback "
@@ -976,7 +1000,10 @@ class GrowthReporter:
                         self._leaderboard_chart(
                             f"chart-lb-user-{key}-top",
                             f"Top {n} users by {label}",
-                            [{"label": u.username, "value": value_fn(u)} for u in top],
+                            [
+                                {"label": u.username, "value": _lb_value(value_fn(u))}
+                                for u in top
+                            ],
                             hint,
                         )
                     )
@@ -987,7 +1014,7 @@ class GrowthReporter:
                             f"chart-lb-user-{key}-bottom",
                             f"Bottom {n} users by {label}",
                             [
-                                {"label": u.username, "value": value_fn(u)}
+                                {"label": u.username, "value": _lb_value(value_fn(u))}
                                 for u in bottom
                             ],
                             hint,

--- a/cometx/cli/admin_growth_report.py
+++ b/cometx/cli/admin_growth_report.py
@@ -32,12 +32,22 @@ from tqdm import tqdm
 from cometx.cli.admin_growth_render import build_html, write_html
 from cometx.cli.admin_growth_users import (
     active_series,
+    adoption_rate_series,
     adoption_stats,
     bottom_users,
     capability_series,
+    churn_series,
     classify_accounts,
+    em_user_breakdown_series,
+    opik_user_breakdown_series,
     parse_users,
+    parse_workspaces,
+    platform_mix,
     top_users,
+    workspace_active_series,
+    workspace_active_stats,
+    workspace_churn_series,
+    workspace_org_totals,
 )
 from cometx.utils import fetch_chargeback_report, format_time_key, get_next_time_key
 
@@ -202,6 +212,68 @@ def _fetch_service_accounts(api) -> "set[str] | None":
         return _extract_service_account_names(payload)
     except Exception:
         return None
+
+
+def _short_api_error(exc):
+    """Condense a verbose SDK/HTTP exception (which may dump full response
+    headers, cookies, and CSP) into a single short line: "status: message"
+    when parseable, else a truncated one-liner. Keeps per-workspace warnings
+    readable instead of pasting a wall of response headers per failure."""
+    text = " ".join(str(exc).split())
+    status = re.search(r"status_code:\s*(\d+)", text)
+    message = re.search(r"'message':\s*'([^']*)'", text)
+    if status or message:
+        parts = []
+        if status:
+            parts.append(status.group(1))
+        if message:
+            parts.append(message.group(1))
+        return ": ".join(parts)
+    return text if len(text) <= 160 else text[:157] + "..."
+
+
+def _chargeback_licensed_users(chargeback):
+    """Return the raw licensed-user records from a chargeback dict, tolerating
+    the same container shapes as `admin_growth_users.parse_users` (dict with
+    `licensedUsers`, dict with `report`, or a bare list)."""
+    users_field = (chargeback or {}).get("users")
+    if isinstance(users_field, dict):
+        if "licensedUsers" in users_field:
+            return users_field.get("licensedUsers") or []
+        report = users_field.get("report")
+        if report is not None:
+            return _chargeback_licensed_users({"users": report})
+        return []
+    if isinstance(users_field, list):
+        return users_field
+    return []
+
+
+def _scope_chargeback(chargeback, workspace_names):
+    """Narrow an org-wide chargeback dict to `workspace_names`: keep only those
+    workspaces and only the users who are members of them. Lets the People /
+    leaderboards / personal-vs-service layers match an explicit workspace
+    selection instead of always reporting org-wide."""
+    wanted = set(workspace_names)
+    workspaces = [
+        w for w in (chargeback.get("workspaces") or []) if w.get("name") in wanted
+    ]
+    members = {
+        m.get("userName")
+        for w in workspaces
+        for m in (w.get("members") or [])
+        if m.get("userName")
+    }
+    scoped_users = [
+        u
+        for u in _chargeback_licensed_users(chargeback)
+        if u.get("username") in members
+    ]
+    return {
+        **chargeback,
+        "workspaces": workspaces,
+        "users": {"licensedUsers": scoped_users},
+    }
 
 
 def _as_float(value):
@@ -411,8 +483,18 @@ class GrowthReporter:
         print("Building report...")
 
         now_ms = int(now.timestamp() * 1000)
+        # Explicit WORKSPACE args scope the whole report (incl. the org-wide
+        # chargeback layers); with no args the chargeback layers stay org-wide.
+        scope = set(resolved_workspaces) if workspaces else None
         return self._assemble_report_data(
-            events, usage, ran, resolved_workspaces, window, chargeback, now_ms
+            events,
+            usage,
+            ran,
+            resolved_workspaces,
+            window,
+            chargeback,
+            now_ms,
+            scope=scope,
         )
 
     def _now(self):
@@ -571,7 +653,7 @@ class GrowthReporter:
         rows = sorted(events, key=lambda ev: ev.created, reverse=True)
         return {
             "title": kind_label,
-            "headers": ["Use case", "Created"],
+            "headers": ["Project", "Created"],
             "rows": [[ev.use_case, ev.created.date().isoformat()] for ev in rows],
         }
 
@@ -595,8 +677,8 @@ class GrowthReporter:
             }
         rows = sorted(unified_events(events), key=lambda ev: ev.created, reverse=True)
         return {
-            "title": "Use cases",
-            "headers": ["Use case", "Kind", "Created"],
+            "title": "Projects",
+            "headers": ["Project", "Kind", "Created"],
             "rows": [
                 [
                     ev.use_case,
@@ -604,6 +686,25 @@ class GrowthReporter:
                     ev.created.date().isoformat(),
                 ]
                 for ev in rows
+            ],
+        }
+
+    def _workspace_chargeback_table(self, ws_records):
+        """Org-wide by-workspace table from chargeback (top 20 by experiments):
+        projects, experiments and data logged per workspace."""
+        rows = sorted(ws_records, key=lambda w: -w.num_experiments)[:20]
+        return {
+            "title": "By workspace (org-wide, chargeback)",
+            "headers": ["Workspace", "Members", "Projects", "Experiments", "Data (MB)"],
+            "rows": [
+                [
+                    w.name,
+                    len(w.members),
+                    w.num_projects,
+                    _num(w.num_experiments),
+                    _num(round(w.data_mb)),
+                ]
+                for w in rows
             ],
         }
 
@@ -617,7 +718,7 @@ class GrowthReporter:
         return {
             "id": "chart-unified-created",
             "kind": "stackedBars",
-            "title": "Use cases created",
+            "title": "Projects created",
             "hint": f"by kind · {self.units}ly",
             "legend": [
                 {"label": "Opik", "color": "--accent"},
@@ -634,49 +735,358 @@ class GrowthReporter:
             },
         }
 
-    def _unified_department_chart(self, unified):
-        by_ws = use_cases_by_workspace(unified)
-        rows = sorted(
-            (
-                {"label": ws, "value": entry["use_cases_total"]}
-                for ws, entry in by_ws.items()
-            ),
-            key=lambda r: -r["value"],
-        )
+    def _platform_stacked_chart(self, events, chart_id, title):
+        """Per-period stacked bars of `events` split by platform (Opik / EM /
+        MPM). Returns `None` when there are no events to bucket."""
+        platforms = ("opik", "em", "mpm")
+        by_platform = {p: [ev for ev in events if ev.platform == p] for p in platforms}
+        points = _stacked_points(by_platform, self.units, platforms)
+        if not points:
+            return None
         return {
-            "id": "chart-unified-by-workspace",
-            "kind": "groupedBarsH",
-            "title": "Use cases by workspace",
-            "hint": "workspaces proxy teams / departments · current totals",
-            "data": {"rows": rows},
+            "id": chart_id,
+            "kind": "stackedBars",
+            "title": title,
+            "hint": f"by platform · {self.units}ly",
+            "legend": [
+                {"label": "Opik", "color": "--accent"},
+                {"label": "EM", "color": "--sdk"},
+                {"label": "MPM", "color": "--ok"},
+            ],
+            "data": {
+                "categories": list(platforms),
+                "labels": {p: PLATFORM_LABELS[p] for p in platforms},
+                "colors": ["--accent", "--sdk", "--ok"],
+                "points": points,
+                "window_start": None,
+                "window_end": None,
+            },
         }
 
-    def _build_unified_section(self, events, window, workspaces_count):
-        unified = unified_events(events)
-        count_before = sum(1 for ev in unified if ev.created < window.start)
-        stats = growth_stats(unified, window, self.units)
-        spec = self.window or "7d"
+    def _cumulative_area_chart(self, events, chart_id, title):
+        """Cumulative running-total area chart of `events`, bucketed by
+        `self.units` and zero-filled across all periods. Returns `None` with
+        fewer than two periods to plot (no trajectory to show)."""
+        counts = defaultdict(int)
+        for ev in events:
+            counts[format_time_key(ev.created, self.units)] += 1
+        cum = cumulative(continuous_series(counts, self.units))  # [(key, total)]
+        if len(cum) < 2:
+            return None
+        points = [{"key": key, "value": total} for key, total in cum]
         return {
-            "title": "Use cases across all platforms",
+            "id": chart_id,
+            "kind": "area",
+            "title": title,
+            "hint": f"cumulative · {self.units}ly",
+            "data": {
+                "points": points,
+                "window_start": None,
+                "window_end": None,
+            },
+        }
+
+    def _growth_rate_chart(self, events, chart_id, title):
+        """Period-over-period growth-RATE line: each period's new count divided
+        by the cumulative total at the start of the period (the recurring form
+        of the `pct_growth` KPI). WoW when `--units week`, MoM otherwise.
+        Returns `None` with fewer than two periods (a rate needs a prior
+        period). Note: on a small, lumpy population the rate is spiky (a single
+        addition can read as 100%); it smooths out with volume."""
+        counts = {}
+        for ev in events:
+            key = format_time_key(ev.created, self.units)
+            counts[key] = counts.get(key, 0) + 1
+        series = continuous_series(counts, self.units)  # [(key, new)]
+        if len(series) < 2:
+            return None
+        points = []
+        prev_total = 0
+        for key, new in series:
+            rate = round(new / prev_total * 100, 1) if prev_total else 0.0
+            points.append({"key": key, "values": {"rate": rate}})
+            prev_total += new
+        period = (
+            "week-over-week"
+            if self.units == "week"
+            else f"{self.units}-over-{self.units}"
+        )
+        return {
+            "id": chart_id,
+            "kind": "lines",
+            "title": f"{title} ({period})",
+            "hint": "new / cumulative total at start of period",
+            "legend": [{"label": "Growth rate", "color": "--accent"}],
+            "data": {
+                "categories": ["rate"],
+                "labels": {"rate": "Growth rate"},
+                "colors": ["--accent"],
+                "points": points,
+                "window_start": None,
+                "window_end": None,
+            },
+        }
+
+    @staticmethod
+    def _workspace_first_events(unified):
+        """One synthetic creation event per workspace, at the earliest
+        project-creation seen in it (its "created" proxy). Feeds the
+        workspace-level created / cumulative / growth views in the summary
+        section; each retains the platform of that earliest project."""
+        first = {}
+        for ev in unified:
+            cur = first.get(ev.workspace)
+            if cur is None or ev.created < cur.created:
+                first[ev.workspace] = ev
+        return list(first.values())
+
+    @staticmethod
+    def _workspace_growth_kpi(users, window):
+        """Org-wide workspace growth over the analysis window: workspaces first
+        seen in-window vs. those existing before it, using each workspace's
+        earliest member `created_at` as its creation proxy (mirrors the Users
+        section's user-growth KPI). Returns {new_in, before, pct}."""
+        ws_created: dict = {}
+        for u in users:
+            if u.created_at is None:
+                continue
+            for ws in u.workspaces:
+                cur = ws_created.get(ws)
+                if cur is None or u.created_at < cur:
+                    ws_created[ws] = u.created_at
+        new_in = sum(
+            1
+            for c in ws_created.values()
+            if window.start <= _ms_to_utc(c) <= window.end
+        )
+        before = sum(1 for c in ws_created.values() if _ms_to_utc(c) < window.start)
+        pct = round(new_in / before * 100, 1) if before else 0.0
+        return {"new_in": new_in, "before": before, "pct": pct}
+
+    def _build_unified_section(
+        self,
+        events,
+        window,
+        workspaces_count,
+        people_users=None,
+        ws_records=None,
+        now_ms=None,
+        active_window_days=None,
+    ):
+        """Top workspace-and-project section. When chargeback data is present
+        (`ws_records` / `people_users`), the KPIs and platform-mix are ORG-WIDE
+        from chargeback (workspaces, projects, experiments, active %); the
+        project/workspace *creation timelines* remain SDK-derived (accessible
+        workspaces only) since chargeback carries no creation dates. Every
+        workspace-level number lives here; the Users section stays about
+        users."""
+        unified = unified_events(events)
+        ws_events = self._workspace_first_events(unified)
+        proj_stats = growth_stats(unified, window, self.units)
+        ws_stats = growth_stats(ws_events, window, self.units)
+        spec = self.window or "7d"
+
+        # SDK-derived creation timelines (accessible workspaces only). These are
+        # the "project-based" charts; when chargeback is present they move to
+        # their per-product sections and this org section stays chargeback-only.
+        sdk_charts = [
+            self._platform_stacked_chart(
+                ws_events, "chart-unified-workspaces-created", "Workspaces created"
+            ),
+            self._cumulative_area_chart(
+                ws_events,
+                "chart-unified-workspaces-cumulative",
+                "Total workspaces over time",
+            ),
+            self._growth_rate_chart(
+                ws_events, "chart-unified-workspaces-rate", "Workspace growth rate"
+            ),
+            self._unified_stacked_chart(events, window),
+            self._cumulative_area_chart(
+                unified,
+                "chart-unified-projects-cumulative",
+                "Total projects over time",
+            ),
+            self._growth_rate_chart(
+                unified, "chart-unified-projects-rate", "Project growth rate"
+            ),
+        ]
+
+        # Chargeback-derived org-wide charts (total-vs-active, added/deleted,
+        # platform mix) — only when chargeback users/records are present.
+        cb_charts = []
+        ws_kpi_extra = []
+        if people_users:
+            ws_active_pts = workspace_active_series(
+                people_users, self.units, now_ms, active_window_days
+            )
+            if ws_active_pts:
+                cb_charts.append(
+                    {
+                        "id": "chart-unified-workspaces-active",
+                        "kind": "lines",
+                        "title": "Workspaces: total vs. active",
+                        "hint": (
+                            f"org-wide (chargeback); active window "
+                            f"{self.active_window}"
+                        ),
+                        "legend": [
+                            {"label": "Total", "color": "--sdk"},
+                            {"label": "Active", "color": "--ok"},
+                        ],
+                        "data": {
+                            "categories": ["total", "active"],
+                            "labels": {"total": "Total", "active": "Active"},
+                            "colors": ["--sdk", "--ok"],
+                            "points": ws_active_pts,
+                            "window_start": None,
+                            "window_end": None,
+                        },
+                    }
+                )
+            ws_churn = workspace_churn_series(people_users, self.units, now_ms)
+            if ws_churn:
+                # added/deleted as bars, with an overlaid growth-rate line
+                # (added workspaces / cumulative at start of period).
+                churn_pts = []
+                prev_total = 0
+                for pt in ws_churn:
+                    added = pt["values"]["added"]
+                    deleted = pt["values"]["deleted"]
+                    rate = round(added / prev_total * 100, 1) if prev_total else 0.0
+                    churn_pts.append(
+                        {
+                            "key": pt["key"],
+                            "values": {
+                                "added": added,
+                                "deleted": deleted,
+                                "rate": rate,
+                            },
+                        }
+                    )
+                    prev_total += added
+                cb_charts.append(
+                    {
+                        "id": "chart-unified-workspace-churn",
+                        "kind": "barsLine",
+                        "title": "Workspaces added vs. deleted",
+                        "hint": (
+                            f"org-wide (chargeback) · {self.units}ly · "
+                            "deletion is a proxy"
+                        ),
+                        "legend": [
+                            {"label": "Added", "color": "--ok"},
+                            {"label": "Deleted", "color": "--warn"},
+                            {"label": "Growth rate", "color": "--accent"},
+                        ],
+                        "data": {
+                            "points": churn_pts,
+                            "bars": ["added", "deleted"],
+                            "line": "rate",
+                            "bar_labels": {"added": "Added", "deleted": "Deleted"},
+                            "bar_colors": ["--ok", "--warn"],
+                            "line_label": "Growth rate",
+                            "line_color": "--accent",
+                            "window_start": None,
+                            "window_end": None,
+                        },
+                    }
+                )
+            wa = workspace_active_stats(people_users, now_ms, active_window_days)
+            ws_kpi_extra.append(
+                {
+                    "label": "Active workspaces %",
+                    "value": f"{wa['active_pct']}%",
+                    "sub": f"{wa['active']}/{wa['total']} active",
+                }
+            )
+
+        # Org-wide platform mix (chargeback): EM-only / Opik-only / both /
+        # neither. MPM is not in chargeback, so it's excluded; Opik is a
+        # per-user proxy (a member's Opik usage is attributed to all their
+        # workspaces).
+        if ws_records:
+            mix = platform_mix(ws_records, people_users or [])
+            mix_rows = [
+                {"label": "EM only", "value": mix["em_only"]},
+                {"label": "Opik only", "value": mix["opik_only"]},
+                {"label": "EM + Opik", "value": mix["both"]},
+                {"label": "Neither", "value": mix["neither"]},
+            ]
+            cb_charts.append(
+                {
+                    "id": "chart-unified-platform-mix",
+                    "kind": "groupedBarsH",
+                    "title": "Workspace platform mix",
+                    "hint": (
+                        "org-wide (chargeback); Opik is a per-user proxy; "
+                        "MPM not represented in chargeback"
+                    ),
+                    "data": {"rows": mix_rows},
+                }
+            )
+
+        if ws_records:
+            # ORGANIZATION OVERVIEW (chargeback): org-wide headline numbers and
+            # chargeback-derived charts only. The SDK creation timelines move to
+            # their per-product growth sections.
+            org = workspace_org_totals(ws_records)
+            wa = workspace_active_stats(
+                people_users or [],
+                now_ms,
+                active_window_days,
+                all_workspaces={w.name for w in ws_records},
+            )
+            wg = self._workspace_growth_kpi(people_users or [], window)
+            kpis = [
+                {"label": "Total workspaces", "value": org["workspaces"]},
+                {
+                    "label": "Total projects",
+                    "value": org["projects"],
+                    "sub": "EM projects",
+                    "tone": "ok",
+                },
+                {
+                    "label": f"New in {spec} (% of base)",
+                    "value": f"{wg['pct']}%",
+                    "sub": f"+{wg['new_in']} new",
+                },
+                {
+                    "label": "Active workspaces %",
+                    "value": f"{wa['active_pct']}%",
+                    "sub": f"{wa['active']}/{wa['total']} active",
+                },
+            ]
+            return {
+                "title": "Organization overview (chargeback)",
+                "window_chip": self._window_label(window),
+                "kpis": kpis,
+                "charts": [c for c in cb_charts if c],
+                "table": self._workspace_chargeback_table(ws_records),
+            }
+
+        # No chargeback -> SDK-only fallback (accessible workspaces): keep the
+        # creation timelines and SDK headline here.
+        kpis = [{"label": "Total workspaces", "value": workspaces_count}]
+        kpis += ws_kpi_extra
+        kpis += [
+            {"label": "Total projects", "value": proj_stats["total"], "tone": "ok"},
+            {
+                "label": f"New workspaces in {spec} (% of base)",
+                "value": f"{ws_stats['pct_growth']}%",
+                "sub": f"+{ws_stats['new_in_window']} new",
+            },
+            {
+                "label": f"New projects in {spec} (% of base)",
+                "value": f"{proj_stats['pct_growth']}%",
+                "sub": f"+{proj_stats['new_in_window']} new",
+            },
+        ]
+        return {
+            "title": "Workspaces & projects (accessible)",
             "window_chip": self._window_label(window),
-            "kpis": [
-                {
-                    "label": "Workspaces",
-                    "value": workspaces_count,
-                    "sub": "proxy for teams / departments",
-                },
-                {"label": "Use cases", "value": stats["total"], "tone": "ok"},
-                {"label": f"New ({spec})", "value": f"+{stats['new_in_window']}"},
-                {
-                    "label": f"Growth ({spec})",
-                    "value": f"{stats['pct_growth']}%",
-                    "sub": f"vs {count_before} before window",
-                },
-            ],
-            "charts": [
-                self._unified_stacked_chart(events, window),
-                self._unified_department_chart(unified),
-            ],
+            "kpis": kpis,
+            "charts": [c for c in (sdk_charts + cb_charts) if c],
             "table": self._unified_table(events, workspaces_count),
         }
 
@@ -883,29 +1293,38 @@ class GrowthReporter:
             "window_chip": self._window_label(window),
             "kpis": self._growth_kpis(stats, count_before, len(workspaces_with_kind)),
             "charts": [
-                {
-                    "id": f"chart-{platform}-bars",
-                    "kind": "bars",
-                    "title": f"New {KIND_LABELS[kind]}",
-                    "hint": f"by {self.units}",
-                    "data": {
-                        "points": points,
-                        "window_start": window_start,
-                        "window_end": window_end,
+                chart
+                for chart in (
+                    {
+                        "id": f"chart-{platform}-bars",
+                        "kind": "bars",
+                        "title": f"New {KIND_LABELS[kind]}",
+                        "hint": f"by {self.units}",
+                        "data": {
+                            "points": points,
+                            "window_start": window_start,
+                            "window_end": window_end,
+                        },
                     },
-                },
-                {
-                    "id": f"chart-{platform}-area",
-                    "kind": "area",
-                    "title": f"{KIND_LABELS[kind]} — cumulative",
-                    "hint": "all-time",
-                    "data": {
-                        "points": cum_points,
-                        "window_start": window_start,
-                        "window_end": window_end,
-                        "delta": stats["new_in_window"],
+                    {
+                        "id": f"chart-{platform}-area",
+                        "kind": "area",
+                        "title": f"{KIND_LABELS[kind]} — cumulative",
+                        "hint": "all-time",
+                        "data": {
+                            "points": cum_points,
+                            "window_start": window_start,
+                            "window_end": window_end,
+                            "delta": stats["new_in_window"],
+                        },
                     },
-                },
+                    self._growth_rate_chart(
+                        kind_events,
+                        f"chart-{platform}-rate",
+                        f"{KIND_LABELS[kind]} growth rate",
+                    ),
+                )
+                if chart
             ],
             "table": self._breakdown_table(
                 kind_events, KIND_LABELS[kind], workspaces_count
@@ -925,40 +1344,60 @@ class GrowthReporter:
         active_window = parse_window(self.active_window, now, self.units)
         return max(1, (active_window.end - active_window.start).days)
 
-    def _build_people_section(self, chargeback, now_ms):
-        """Users/adoption section, derived from the chargeback report (Task
-        4 helpers). KPIs (Total / Active / Adoption %) plus real over-time
-        `lines` charts: active-vs-total (Task 6's `active_series`), and,
-        when at least one user has an EM/Opik capability timestamp, a
-        per-capability active-users chart (`capability_series`)."""
+    def _build_people_section(self, users, now_ms, window=None):
+        """User-level section (workspace metrics live in the Organization
+        overview). KPIs (Total / Active / Active % / new-in-window % of base)
+        plus over-time
+        `lines` charts: active-vs-total, adoption rates, per-capability active
+        users, EM/Opik user breakdowns, and users added-vs-deleted. `users` is
+        the pre-parsed (and, when scoped, already-filtered) chargeback user
+        list. Returns `None` when there are no users."""
+        if not users:
+            return None
         now = _ms_to_utc(now_ms)
         active_window_days = self._active_window_days(now)
 
-        users = parse_users(chargeback)
         stats = adoption_stats(users, now_ms, active_window_days)
 
         kpis = [
-            {"label": "Total", "value": stats["total"]},
+            {"label": "Total users", "value": stats["total"]},
             {
-                "label": f"Active ({self.active_window})",
+                "label": f"Active users ({self.active_window})",
                 "value": stats["active"],
             },
-            {"label": "Adoption %", "value": f"{stats['adoption_pct']}%"},
+            {"label": "Active users %", "value": f"{stats['adoption_pct']}%"},
         ]
 
+        # User growth over the analysis window: new accounts in window /
+        # accounts before window (mirrors the workspace/project growth KPI).
+        if window is not None:
+            new_in = sum(
+                1
+                for u in users
+                if u.created_at is not None
+                and window.start <= _ms_to_utc(u.created_at) <= window.end
+            )
+            before = sum(
+                1
+                for u in users
+                if u.created_at is not None and _ms_to_utc(u.created_at) < window.start
+            )
+            pct = round(new_in / before * 100, 1) if before else 0.0
+            kpis.append(
+                {
+                    "label": f"New in {self.window or '7d'} (% of base)",
+                    "value": f"{pct}%",
+                    "sub": f"+{new_in} new",
+                }
+            )
+
         active_pts = active_series(users, self.units, now_ms, active_window_days)
-        if active_pts:
-            window_start = active_pts[0]["key"]
-            window_end = active_pts[-1]["key"]
-            points = active_pts
-        else:
+        if not active_pts:
             # No user has a known created_at to bucket from -- degrade to a
             # single current-period point rather than an empty chart.
-            bucket_key = format_time_key(now, self.units)
-            window_start = window_end = bucket_key
-            points = [
+            active_pts = [
                 {
-                    "key": bucket_key,
+                    "key": format_time_key(now, self.units),
                     "values": {"total": stats["total"], "active": stats["active"]},
                 }
             ]
@@ -977,12 +1416,40 @@ class GrowthReporter:
                     "categories": ["total", "active"],
                     "labels": {"total": "Total", "active": "Active"},
                     "colors": ["--sdk", "--ok"],
-                    "points": points,
-                    "window_start": window_start,
-                    "window_end": window_end,
+                    "points": active_pts,
+                    "window_start": None,
+                    "window_end": None,
                 },
             }
         ]
+
+        rate_pts = adoption_rate_series(users, self.units, now_ms, active_window_days)
+        if rate_pts:
+            charts.append(
+                {
+                    "id": "chart-people-adoption-rate",
+                    "kind": "lines",
+                    "title": "Adoption rates",
+                    "hint": f"active users / total; active window {self.active_window} · {self.units}ly",
+                    "legend": [
+                        {"label": "Overall", "color": "--ok"},
+                        {"label": "Experimentation", "color": "--sdk"},
+                        {"label": "Opik", "color": "--accent"},
+                    ],
+                    "data": {
+                        "categories": ["overall", "em", "opik"],
+                        "labels": {
+                            "overall": "Overall",
+                            "em": "Experimentation",
+                            "opik": "Opik",
+                        },
+                        "colors": ["--ok", "--sdk", "--accent"],
+                        "points": rate_pts,
+                        "window_start": None,
+                        "window_end": None,
+                    },
+                }
+            )
 
         cap_pts = capability_series(users, self.units, now_ms, active_window_days)
         if cap_pts:
@@ -1001,8 +1468,92 @@ class GrowthReporter:
                         "labels": {"em": "EM", "opik": "Opik"},
                         "colors": ["--sdk", "--accent"],
                         "points": cap_pts,
-                        "window_start": cap_pts[0]["key"],
-                        "window_end": cap_pts[-1]["key"],
+                        "window_start": None,
+                        "window_end": None,
+                    },
+                }
+            )
+
+        window_hint = f"active window {self.active_window} · {self.units}ly"
+
+        em_pts = em_user_breakdown_series(users, self.units, now_ms, active_window_days)
+        if em_pts:
+            charts.append(
+                {
+                    "id": "chart-people-em-breakdown",
+                    "kind": "lines",
+                    "title": "EM users: active, experimenters, data pushers",
+                    "hint": window_hint + "; experimenters/data-pushers from totals",
+                    "legend": [
+                        {"label": "Active", "color": "--sdk"},
+                        {"label": "Experimenters", "color": "--accent"},
+                        {"label": "Data pushers", "color": "--warn"},
+                    ],
+                    "data": {
+                        "categories": ["active", "experimenters", "data_pushers"],
+                        "labels": {
+                            "active": "Active",
+                            "experimenters": "Experimenters",
+                            "data_pushers": "Data pushers",
+                        },
+                        "colors": ["--sdk", "--accent", "--warn"],
+                        "points": em_pts,
+                        "window_start": None,
+                        "window_end": None,
+                    },
+                }
+            )
+
+        opik_pts = opik_user_breakdown_series(
+            users, self.units, now_ms, active_window_days
+        )
+        if opik_pts:
+            charts.append(
+                {
+                    "id": "chart-people-opik-breakdown",
+                    "kind": "lines",
+                    "title": "Opik users: active, span producers",
+                    "hint": window_hint + "; span-producers from totals",
+                    "legend": [
+                        {"label": "Active", "color": "--accent"},
+                        {"label": "Span producers", "color": "--ok"},
+                    ],
+                    "data": {
+                        "categories": ["active", "span_producers"],
+                        "labels": {
+                            "active": "Active",
+                            "span_producers": "Span producers",
+                        },
+                        "colors": ["--accent", "--ok"],
+                        "points": opik_pts,
+                        "window_start": None,
+                        "window_end": None,
+                    },
+                }
+            )
+
+        user_churn = churn_series(users, self.units, now_ms)
+        if user_churn:
+            charts.append(
+                {
+                    "id": "chart-people-user-churn",
+                    "kind": "lines",
+                    "title": "Users added vs. deleted",
+                    "hint": (
+                        f"per period · {self.units}ly; deletions reflect soft-deletes "
+                        "still present in the snapshot"
+                    ),
+                    "legend": [
+                        {"label": "Added", "color": "--ok"},
+                        {"label": "Deleted", "color": "--warn"},
+                    ],
+                    "data": {
+                        "categories": ["added", "deleted"],
+                        "labels": {"added": "Added", "deleted": "Deleted"},
+                        "colors": ["--ok", "--warn"],
+                        "points": user_churn,
+                        "window_start": None,
+                        "window_end": None,
                     },
                 }
             )
@@ -1023,92 +1574,164 @@ class GrowthReporter:
         }
 
         return {
-            "title": "Users & adoption",
+            "title": "Users",
             "kpis": kpis,
             "charts": charts,
             "table": table,
         }
 
-    # Workspace-level leaderboard metrics per platform: (metric name, plain
-    # label used in chart titles, e.g. "Top 5 workspaces by {label}").
-    _LEADERBOARD_METRICS = {
-        "em": [("EXPERIMENT_COUNT", "experiments")],
-        "opik": [("SPAN_COUNT", "spans"), ("TRACE_COUNT", "traces")],
-        "mpm": [("PREDICTION_VOLUME", "predictions")],
-    }
-
     # User-level leaderboard metrics: (top_users/bottom_users key, plain
     # label, value-extractor matching admin_growth_users._metric_value).
     _USER_LEADERBOARD_METRICS = [
-        ("opik_span_count", "Opik spans", lambda u: u.opik_span_count),
-        ("em_score", "activity", lambda u: u.experiment_count + u.data_logged_mb),
+        (
+            "opik_span_count",
+            "Opik spans",
+            lambda u: u.opik_span_count,
+            "org-wide (chargeback)",
+        ),
+        (
+            "em_score",
+            "EM activity",
+            lambda u: u.experiment_count + u.data_logged_mb,
+            "EM activity = experiments + data logged (MB); org-wide (chargeback)",
+        ),
     ]
 
     @staticmethod
-    def _leaderboard_chart(chart_id, title, rows):
-        return {
+    def _leaderboard_chart(chart_id, title, rows, hint=None):
+        chart = {
             "id": chart_id,
             "kind": "groupedBarsH",
             "title": title,
             "data": {"rows": rows},
         }
+        if hint:
+            chart["hint"] = hint
+        return chart
 
-    def _build_leaderboards_section(self, usage, users, ran):
-        """Top-N / bottom-N leaderboards: one per workspace-level metric of
-        each platform that actually ran (Task 5's `ran` map), plus user
-        leaderboards (by `opik_span_count`, by `em_score`) when `users` is
-        non-empty. Bottom-N is active-aware (strictly-positive values only,
-        ascending -- mirrors `bottom_users`). Platforms/metrics with no data
-        are omitted entirely (no empty panels); returns `None` when there is
-        nothing to show at all."""
+    @staticmethod
+    def _workspace_rollup(users, value_fn):
+        """Sum a per-user chargeback metric across each user's workspaces.
+        Approximate: chargeback carries per-user totals (not per-workspace), so
+        a user in multiple workspaces contributes their full total to each."""
+        totals = {}
+        for u in users:
+            value = value_fn(u) or 0
+            if value <= 0:
+                continue
+            for ws in u.workspaces:
+                totals[ws] = totals.get(ws, 0) + value
+        return totals
+
+    def _build_leaderboards_section(self, usage, users, ran, ws_records=None):
+        """Top-N / bottom-N workspace and user leaderboards.
+
+        Experiments and projects are ranked ORG-WIDE and EXACTLY from the
+        chargeback per-workspace numbers (`ws_records`) when available, else
+        from the SDK (accessible workspaces). Opik spans are org-wide from the
+        chargeback per-user rollup (a proxy: a member's spans are attributed to
+        each of their workspaces), else SDK. Traces and predictions have no
+        per-user/per-workspace chargeback field, so they stay SDK-sourced
+        (accessible workspaces only). Bottom-N is active-aware
+        (strictly-positive, ascending). Empty metrics are omitted; returns
+        `None` when there is nothing to show."""
         n = self.leaderboard_top_n
         charts = []
 
-        for platform, metrics in self._LEADERBOARD_METRICS.items():
-            if not ran.get(platform):
-                continue
-            for metric, label in metrics:
-                ws_metrics = [
-                    m
-                    for m in usage
-                    if m.platform == platform
-                    and m.metric == metric
-                    and m.project is None
-                ]
-                if not ws_metrics:
-                    continue
-
-                ranked_desc = sorted(ws_metrics, key=lambda m: m.value, reverse=True)
-                top_rows = [
-                    {"label": m.workspace, "value": m.value} for m in ranked_desc[:n]
-                ]
-                active_asc = sorted(
-                    (m for m in ws_metrics if m.value > 0), key=lambda m: m.value
+        def emit_ws(slug, label, totals, hint):
+            if not totals:
+                return
+            ranked = sorted(totals.items(), key=lambda kv: kv[1], reverse=True)
+            top_rows = [{"label": ws, "value": _num(v)} for ws, v in ranked[:n]]
+            active_asc = sorted(
+                ((ws, v) for ws, v in totals.items() if v > 0), key=lambda kv: kv[1]
+            )
+            bottom_rows = [{"label": ws, "value": _num(v)} for ws, v in active_asc[:n]]
+            if top_rows:
+                charts.append(
+                    self._leaderboard_chart(
+                        f"chart-lb-{slug}-top",
+                        f"Top {n} workspaces by {label}",
+                        top_rows,
+                        hint,
+                    )
                 )
-                bottom_rows = [
-                    {"label": m.workspace, "value": m.value} for m in active_asc[:n]
-                ]
+            if bottom_rows:
+                charts.append(
+                    self._leaderboard_chart(
+                        f"chart-lb-{slug}-bottom",
+                        f"Bottom {n} workspaces by {label}",
+                        bottom_rows,
+                        hint,
+                    )
+                )
 
-                slug = f"{platform}-{metric.lower()}"
-                if top_rows:
-                    charts.append(
-                        self._leaderboard_chart(
-                            f"chart-lb-{slug}-top",
-                            f"Top {n} workspaces by {label}",
-                            top_rows,
-                        )
-                    )
-                if bottom_rows:
-                    charts.append(
-                        self._leaderboard_chart(
-                            f"chart-lb-{slug}-bottom",
-                            f"Bottom {n} workspaces by {label}",
-                            bottom_rows,
-                        )
-                    )
+        def sdk_totals(platform, metric):
+            return {
+                m.workspace: m.value
+                for m in usage
+                if m.platform == platform and m.metric == metric and m.project is None
+            }
+
+        org_exact_hint = "org-wide, exact (chargeback per-workspace)"
+        org_proxy_hint = (
+            "org-wide from chargeback; per-user spans attributed to each of "
+            "the user's workspaces (proxy)"
+        )
+        sdk_hint = "accessible workspaces only (SDK)"
+
+        # Experiments + projects: exact, org-wide from chargeback per-workspace
+        # numbers when available, else SDK (accessible workspaces).
+        if ws_records:
+            emit_ws(
+                "ws-experiments",
+                "experiments",
+                {w.name: w.num_experiments for w in ws_records if w.num_experiments},
+                org_exact_hint,
+            )
+            emit_ws(
+                "ws-projects",
+                "projects",
+                {w.name: w.num_projects for w in ws_records if w.num_projects},
+                org_exact_hint,
+            )
+        elif ran.get("em"):
+            emit_ws(
+                "em-experiment_count",
+                "experiments",
+                sdk_totals("em", "EXPERIMENT_COUNT"),
+                sdk_hint,
+            )
+
+        # Opik spans: org-wide per-user rollup proxy when users present, else SDK.
+        if users:
+            emit_ws(
+                "ws-spans",
+                "Opik spans",
+                self._workspace_rollup(users, lambda u: u.opik_span_count or 0),
+                org_proxy_hint,
+            )
+        elif ran.get("opik"):
+            emit_ws(
+                "opik-span_count",
+                "Opik spans",
+                sdk_totals("opik", "SPAN_COUNT"),
+                sdk_hint,
+            )
+
+        # Predictions have no per-user chargeback field -> SDK only. (The
+        # workspace-by-traces board was removed: traces aren't a useful
+        # per-workspace ranking here and are SDK/accessible-only anyway.)
+        if ran.get("mpm"):
+            emit_ws(
+                "mpm-prediction_volume",
+                "predictions",
+                sdk_totals("mpm", "PREDICTION_VOLUME"),
+                sdk_hint,
+            )
 
         if users:
-            for key, label, value_fn in self._USER_LEADERBOARD_METRICS:
+            for key, label, value_fn, hint in self._USER_LEADERBOARD_METRICS:
                 top = top_users(users, key, n)
                 if top:
                     charts.append(
@@ -1116,6 +1739,7 @@ class GrowthReporter:
                             f"chart-lb-user-{key}-top",
                             f"Top {n} users by {label}",
                             [{"label": u.username, "value": value_fn(u)} for u in top],
+                            hint,
                         )
                     )
                 bottom = bottom_users(users, key, n)
@@ -1128,6 +1752,7 @@ class GrowthReporter:
                                 {"label": u.username, "value": value_fn(u)}
                                 for u in bottom
                             ],
+                            hint,
                         )
                     )
 
@@ -1162,7 +1787,7 @@ class GrowthReporter:
         hint = (
             "Source: service accounts from admin API."
             if source == "admin_api"
-            else "Source: heuristic (regex); admin API service-account data unavailable."
+            else "Source: heuristic (regex); admin API returned no service accounts."
         )
 
         charts = []
@@ -1194,11 +1819,80 @@ class GrowthReporter:
             "charts": charts,
         }
 
+    @staticmethod
+    def _scope_label(scope, sdk_count, org_workspaces, org_users, has_chargeback):
+        """One-line scope descriptor for the report header."""
+        if scope is not None:
+            return f"Scoped to {sdk_count} selected workspace(s)"
+        if has_chargeback and org_workspaces is not None:
+            return (
+                f"Org-wide: {org_workspaces} workspaces, {org_users} users "
+                f"(project & growth metrics cover {sdk_count} workspace(s) "
+                "accessible to this key)"
+            )
+        return f"Workspaces accessible to this key: {sdk_count}"
+
     def _assemble_report_data(
-        self, events, usage, ran, workspaces, window, chargeback=None, now_ms=None
+        self,
+        events,
+        usage,
+        ran,
+        workspaces,
+        window,
+        chargeback=None,
+        now_ms=None,
+        scope=None,
     ):
         workspaces_count = len(workspaces)
-        unified_section = self._build_unified_section(events, window, workspaces_count)
+
+        # Org totals from the FULL (unscoped) chargeback, for the header label.
+        # Use the SAME definitions as the section KPIs so header and KPIs never
+        # disagree: total workspaces = the chargeback workspace-list count (the
+        # authoritative "Total workspaces"); users = non-suspended count.
+        org_users = org_workspaces = None
+        if chargeback:
+            try:
+                org_users = sum(1 for u in parse_users(chargeback) if not u.suspended)
+                org_workspaces = len(parse_workspaces(chargeback))
+            except Exception:
+                # Malformed chargeback: fall back to a scope label without org
+                # totals; the section builders below degrade independently.
+                org_users = org_workspaces = None
+
+        # The chargeback layers are org-wide by default; when the caller passed
+        # an explicit workspace set, scope them down to match the SDK summary.
+        scoped_chargeback = chargeback
+        if chargeback and scope is not None:
+            scoped_chargeback = _scope_chargeback(chargeback, scope)
+
+        # Parse the (scoped) chargeback users once; feed the workspace-level
+        # chargeback metrics into the Workspaces & projects section and the
+        # user-level metrics into the Users section + leaderboards.
+        people_users = []
+        ws_records = []
+        active_window_days = None
+        if scoped_chargeback:
+            active_window_days = self._active_window_days(_ms_to_utc(now_ms))
+            try:
+                people_users = parse_users(scoped_chargeback)
+                ws_records = parse_workspaces(scoped_chargeback)
+            except Exception as exc:
+                print(
+                    f"Warning: failed to parse chargeback report; "
+                    f"skipping org layers: {_short_api_error(exc)}"
+                )
+                people_users = []
+                ws_records = []
+
+        unified_section = self._build_unified_section(
+            events,
+            window,
+            workspaces_count,
+            people_users=people_users,
+            ws_records=ws_records,
+            now_ms=now_ms,
+            active_window_days=active_window_days,
+        )
         count_before_unified = sum(
             1 for ev in unified_events(events) if ev.created < window.start
         )
@@ -1222,23 +1916,23 @@ class GrowthReporter:
             )
 
         sections = {"unified": unified_section, "products": products}
-        if chargeback:
+        if people_users:
             try:
-                people_section = self._build_people_section(chargeback, now_ms)
+                people_section = self._build_people_section(
+                    people_users, now_ms, window=window
+                )
             except Exception as exc:
                 print(
-                    f"Warning: failed to build people section from chargeback data; "
-                    f"skipping people layer: {exc}"
+                    f"Warning: failed to build users section from chargeback data; "
+                    f"skipping: {_short_api_error(exc)}"
                 )
                 people_section = None
             if people_section:
                 sections["people"] = people_section
 
-        leaderboard_users = []
         try:
-            leaderboard_users = parse_users(chargeback) if chargeback else []
             leaderboards_section = self._build_leaderboards_section(
-                usage, leaderboard_users, ran
+                usage, people_users, ran, ws_records=ws_records
             )
         except Exception as exc:
             print(f"Warning: failed to build leaderboards section; skipping: {exc}")
@@ -1248,10 +1942,16 @@ class GrowthReporter:
 
         try:
             personal_vs_service_section = None
-            if leaderboard_users:
+            if people_users:
                 service_account_names = _fetch_service_accounts(self.api)
+                # Admin endpoint first; fall back to the regex heuristic when it
+                # is unavailable (None) OR returns an empty set (no service
+                # accounts listed) -- an empty admin list is uninformative and
+                # would otherwise mislabel every account as personal.
+                if not service_account_names:
+                    service_account_names = None
                 personal_vs_service_section = self._build_personal_vs_service_section(
-                    leaderboard_users, service_account_names
+                    people_users, service_account_names
                 )
         except Exception as exc:
             print(
@@ -1266,6 +1966,13 @@ class GrowthReporter:
                 "title": "Comet growth report",
                 "generated": window.end.isoformat(),
                 "source": "Comet Admin API",
+                "scope": self._scope_label(
+                    scope,
+                    workspaces_count,
+                    org_workspaces,
+                    org_users,
+                    bool(chargeback),
+                ),
             },
             "window": self._build_window_block(window, count_before_unified),
             "collectors": ran,
@@ -1308,7 +2015,7 @@ class GrowthReporter:
                 )
                 projects = (response or {}).get("projects", []) or []
             except Exception as exc:
-                print(f"Warning: failed to list EM projects for workspace {ws}: {exc}")
+                print(f"Note: skipping EM for workspace {ws}: {_short_api_error(exc)}")
                 continue
 
             # The EM `projects` endpoint returns a FALLBACK set (projects from
@@ -1410,7 +2117,10 @@ class GrowthReporter:
                     )
                 )
             except Exception as exc:
-                print(f"Warning: failed to collect EM registry stats for {ws}: {exc}")
+                print(
+                    f"Warning: failed to collect EM registry stats for {ws}: "
+                    f"{_short_api_error(exc)}"
+                )
 
         return events, usage
 
@@ -1477,7 +2187,10 @@ class GrowthReporter:
             try:
                 client = opik.Opik(workspace=ws, api_key=api_key, host=host)
             except Exception as exc:
-                print(f"Warning: failed to init Opik client for workspace {ws}: {exc}")
+                print(
+                    f"Note: skipping Opik for workspace {ws}: "
+                    f"{_short_api_error(exc)}"
+                )
                 continue
 
             try:
@@ -1494,7 +2207,8 @@ class GrowthReporter:
                     page_num += 1
             except Exception as exc:
                 print(
-                    f"Warning: failed to list Opik projects for workspace {ws}: {exc}"
+                    f"Note: skipping Opik for workspace {ws}: "
+                    f"{_short_api_error(exc)}"
                 )
                 continue
 
@@ -1582,12 +2296,14 @@ class GrowthReporter:
                     except Exception as exc:
                         print(
                             f"Warning: failed to collect Opik TRACE_COUNT for "
-                            f"{ws}/{getattr(project, 'name', '?')}: {exc}"
+                            f"{ws}/{getattr(project, 'name', '?')}: "
+                            f"{_short_api_error(exc)}"
                         )
                 except Exception as exc:
                     print(
                         f"Warning: failed to collect Opik project "
-                        f"{ws}/{getattr(project, 'name', '?')}: {exc}"
+                        f"{ws}/{getattr(project, 'name', '?')}: "
+                        f"{_short_api_error(exc)}"
                     )
                     continue
 
@@ -1641,7 +2357,7 @@ class GrowthReporter:
             resp = mpm._client.get("api/mpm/v3/workspaces")
             all_workspaces = (resp or {}).get("workspaces", []) or []
         except Exception as exc:
-            print(f"Warning: failed to list MPM workspaces: {exc}")
+            print(f"Warning: failed to list MPM workspaces: {_short_api_error(exc)}")
             return [], []
 
         interval_type = "HOURLY" if self.units == "hour" else "DAILY"

--- a/cometx/cli/admin_growth_report.py
+++ b/cometx/cli/admin_growth_report.py
@@ -24,10 +24,7 @@ import dataclasses
 import datetime
 import os
 import re
-from collections import defaultdict
 from urllib.parse import urlparse
-
-from tqdm import tqdm
 
 from cometx.cli.admin_growth_render import build_html, write_html
 from cometx.cli.admin_growth_users import (
@@ -49,36 +46,24 @@ from cometx.cli.admin_growth_users import (
     workspace_churn_series,
     workspace_org_totals,
 )
-from cometx.utils import fetch_chargeback_report, format_time_key, get_next_time_key
+from cometx.utils import fetch_chargeback_report, format_time_key
 
 # `build_html` is re-exported here so the growth-report module is the single
 # import surface (tests + callers import it from here). Declaring it in
 # `__all__` documents the intentional re-export without a per-line noqa.
-__all__ = ["generate_growth_report", "GrowthReporter", "build_html", "write_html"]
+__all__ = [
+    "generate_growth_report",
+    "GrowthReporter",
+    "GrowthReportError",
+    "build_html",
+    "write_html",
+]
 
 
-@dataclasses.dataclass(frozen=True)
-class CreationEvent:
-    """A single use-case creation event (one of the 3 use-case kinds only)."""
-
-    platform: str  # em | opik | mpm
-    workspace: str
-    use_case: str  # project or monitored-model name
-    kind: str  # opik_project | em_project | mpm_model
-    created: datetime.datetime
-
-
-@dataclasses.dataclass(frozen=True)
-class UsageMetric:
-    """Secondary per-product adoption-depth metric (NOT a use case)."""
-
-    platform: str  # opik | em | mpm
-    workspace: str
-    metric: str  # SPAN_COUNT | EXPERIMENT_COUNT | REGISTRY_MODELS |
-    # REGISTRY_VERSIONS | PREDICTION_VOLUME
-    value: float  # total (or snapshot for registry)
-    project: str | None = None
-    series: list | None = None  # [(time_key, value), ...]; None for snapshot
+class GrowthReportError(Exception):
+    """Raised when the report cannot be built -- chiefly when the chargeback
+    admin endpoint is unavailable (e.g. a non-admin API key). There is no SDK
+    fallback in this build."""
 
 
 @dataclasses.dataclass(frozen=True)
@@ -88,50 +73,10 @@ class Window:
     units: str = "month"
 
 
-KIND_LABELS = {
-    "opik_project": "Opik projects",
-    "em_project": "EM projects",
-    "mpm_model": "Monitored models",
-}
-
-PLATFORM_LABELS = {"em": "EM", "opik": "Opik", "mpm": "MPM"}
-
-
 def _ms_to_utc(ms) -> datetime.datetime:
     """Convert an epoch-milliseconds timestamp to a timezone-aware UTC
     datetime."""
     return datetime.datetime.fromtimestamp(ms / 1000, tz=datetime.timezone.utc)
-
-
-def continuous_series(counts: dict, units: str):
-    """Earliest->latest keys, zero-filled via get_next_time_key."""
-    if not counts:
-        return []
-    keys = sorted(counts)
-    out, k = [], keys[0]
-    while True:
-        out.append((k, counts.get(k, 0)))
-        if k == keys[-1]:
-            break
-        k = get_next_time_key(k, units)
-    return out
-
-
-def cumulative(series):
-    total, out = 0, []
-    for k, v in series:
-        total += v
-        out.append((k, total))
-    return out
-
-
-def growth_stats(events, window, units) -> dict:
-    """{total, new_in_window, pct_growth} relative to installed base before window."""
-    total = sum(1 for e in events if e.created <= window.end)
-    new_in = sum(1 for e in events if window.start <= e.created <= window.end)
-    before = sum(1 for e in events if e.created < window.start)
-    pct = (new_in / before * 100.0) if before > 0 else 0.0
-    return {"total": total, "new_in_window": new_in, "pct_growth": round(pct, 1)}
 
 
 def _num(value):
@@ -276,52 +221,6 @@ def _scope_chargeback(chargeback, workspace_names):
     }
 
 
-def _as_float(value):
-    """Coerce a collector datapoint value to a float, treating None/blank and
-    any non-numeric value (e.g. a stray string from an SDK/REST response) as
-    0.0 -- keeps count aggregation from crashing on mixed-type payloads."""
-    if value is None or value == "":
-        return 0.0
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return 0.0
-
-
-def _all_time_counts(events, units) -> dict:
-    """Bucket `events` by creation time-key, with NO window filtering --
-    charts always render all-time (Option-A: the window is a shaded band
-    drawn on top, not a data filter)."""
-    counts: dict = defaultdict(int)
-    for ev in events:
-        counts[format_time_key(ev.created, units)] += 1
-    return dict(counts)
-
-
-def _stacked_points(events_by_kind, units, kinds) -> list:
-    """Build zero-filled `{"key": k, "values": {kind: count, ...}}` points
-    for a stackedBars chart, across the union of all-time bucket keys seen
-    for ANY kind (so every series shares one continuous, zero-filled key
-    sequence even if a given kind has no events in some periods)."""
-    per_kind_counts = {
-        kind: _all_time_counts(events, units) for kind, events in events_by_kind.items()
-    }
-    merged: dict = defaultdict(int)
-    for counts in per_kind_counts.values():
-        for key in counts:
-            merged[key] += 0  # ensure key presence without double counting
-    if not merged:
-        return []
-    keys = [k for k, _ in continuous_series(dict(merged), units)]
-    return [
-        {
-            "key": k,
-            "values": {kind: per_kind_counts.get(kind, {}).get(k, 0) for kind in kinds},
-        }
-        for k in keys
-    ]
-
-
 _WINDOW_SPEC_RE = re.compile(r"^(\d+)([dwmy])$")
 _WINDOW_DAYS_PER_UNIT = {"d": 1, "w": 7, "m": 30, "y": 365}
 
@@ -349,59 +248,15 @@ def parse_window(spec, now, units="month") -> Window:
     return Window(start=now - delta, end=now, units=units)
 
 
-USE_CASE_KINDS = ("opik_project", "em_project", "mpm_model")
-
-
-def unified_events(events) -> list:
-    """All three use-case kinds combined for the unified created-over-time
-    series.
-
-    The collectors already emit only the three use-case kinds
-    (`opik_project`/`em_project`/`mpm_model`), so this is effectively a
-    defensive filter -- any other kind (e.g. a synthetic `workspace` event)
-    is excluded. Returns a new list; never mutates `events`.
-    """
-    return [e for e in events if e.kind in USE_CASE_KINDS]
-
-
-def use_cases_by_workspace(events) -> dict:
-    """Per-workspace use-case roll-up.
-
-    Returns ``{workspace: {"use_cases_total": int, "by_kind": {...},
-    "first_created": datetime}}``. `by_kind` always contains all three
-    use-case kinds (0 if absent). `first_created` is the workspace-creation
-    proxy: the earliest use-case `created` timestamp seen in that workspace.
-    Only the three use-case kinds are considered (via `unified_events`).
-    """
-    result: dict = {}
-    for ev in unified_events(events):
-        entry = result.setdefault(
-            ev.workspace,
-            {
-                "use_cases_total": 0,
-                "by_kind": {kind: 0 for kind in USE_CASE_KINDS},
-                "first_created": ev.created,
-            },
-        )
-        entry["use_cases_total"] += 1
-        entry["by_kind"][ev.kind] += 1
-        if ev.created < entry["first_created"]:
-            entry["first_created"] = ev.created
-    return result
-
-
 def generate_growth_report(
     api,
     workspaces,
     *,
     window="7d",
     units="month",
-    platforms="em,opik,mpm",
     output="growth_report.html",
     no_open=False,
-    limit=None,
     active_window="60d",
-    include_users=True,
     leaderboard_top_n=5,
     exclude_personal=False,
     personal_pattern=None,
@@ -410,16 +265,13 @@ def generate_growth_report(
         api,
         window=window,
         units=units,
-        platforms=platforms,
-        limit=limit,
         active_window=active_window,
-        include_users=include_users,
         leaderboard_top_n=leaderboard_top_n,
         exclude_personal=exclude_personal,
         personal_pattern=personal_pattern,
     )
-    report_data = reporter.build(workspaces)  # events + usage -> report_data (C2-C7)
-    path = write_growth_html(report_data, output)  # C8
+    report_data = reporter.build(workspaces)
+    path = write_growth_html(report_data, output)
     if not no_open:
         _open(path)
     return path
@@ -432,10 +284,7 @@ class GrowthReporter:
         *,
         window,
         units,
-        platforms,
-        limit=None,
         active_window="60d",
-        include_users=True,
         leaderboard_top_n=5,
         exclude_personal=False,
         personal_pattern=None,
@@ -443,113 +292,42 @@ class GrowthReporter:
         self.api = api
         self.window = window
         self.units = units
-        self.platforms = platforms
-        self.limit = limit
         self.active_window = active_window
-        self.include_users = include_users
         self.leaderboard_top_n = leaderboard_top_n
         self.exclude_personal = exclude_personal
         self.personal_pattern = personal_pattern
         self._warned_no_personal_pattern = False
 
     def build(self, workspaces):
-        """Resolve window/platforms/workspaces, run the selected collectors,
-        and assemble `report_data` matching the C8 renderer contract (see
-        `.superpowers/sdd/task-C8-report.md`).
-        """
+        """Fetch the org-wide chargeback report (admin API key required) and
+        assemble chargeback-only report_data. Raises GrowthReportError when the
+        chargeback endpoint is unavailable -- there is no SDK fallback."""
         now = self._now()
         window = parse_window(self.window, now, self.units)
-
-        platforms = self._resolve_platforms()
-        print("Resolving workspaces...")
-        resolved_workspaces = self._resolve_workspaces(workspaces)
-        print(
-            f"Collecting {', '.join(platforms) or 'no'} data for "
-            f"{len(resolved_workspaces)} workspace(s)..."
-        )
-        events, usage, ran = self._collect_selected(platforms, resolved_workspaces)
-
-        chargeback = None
-        if self.include_users and platforms:
-            try:
-                print("Collecting users/people data (chargeback report)...")
-                chargeback = fetch_chargeback_report(self.api)
-            except Exception as exc:
-                print(
-                    f"Warning: failed to fetch chargeback report; skipping people layer: {exc}"
-                )
-                chargeback = None
-
+        print("Fetching chargeback report (admin API)...")
+        try:
+            chargeback = fetch_chargeback_report(self.api)
+        except Exception as exc:
+            raise GrowthReportError(
+                "growth-report requires an admin API key: the chargeback "
+                f"endpoint is unavailable ({_short_api_error(exc)}). This "
+                "report is built entirely from the admin chargeback report."
+            ) from exc
+        chargeback = self._filter_personal_chargeback(chargeback)
         print("Building report...")
-
         now_ms = int(now.timestamp() * 1000)
-        # Explicit WORKSPACE args scope the whole report (incl. the org-wide
-        # chargeback layers); with no args the chargeback layers stay org-wide.
-        scope = set(resolved_workspaces) if workspaces else None
-        return self._assemble_report_data(
-            events,
-            usage,
-            ran,
-            resolved_workspaces,
-            window,
-            chargeback,
-            now_ms,
-            scope=scope,
-        )
+        scope = set(workspaces) if workspaces else None
+        return self._assemble_report_data(chargeback, window, now_ms, scope=scope)
 
     def _now(self):
         return datetime.datetime.now(datetime.timezone.utc)
 
-    def _resolve_platforms(self):
-        """`self.platforms` (csv) intersected with {em,opik,mpm}, in a fixed
-        order, dropping opik/mpm if their optional dependency isn't
-        importable (EM has no optional dependency)."""
-        requested = {p.strip() for p in (self.platforms or "").split(",") if p.strip()}
-        resolved = []
-        for platform in ("em", "opik", "mpm"):
-            if platform not in requested:
-                continue
-            if platform == "opik":
-                try:
-                    import opik  # noqa: F401
-                except ImportError:
-                    print("Note: opik not installed; skipping Opik collection")
-                    continue
-            elif platform == "mpm":
-                try:
-                    import comet_mpm  # noqa: F401
-                except ImportError:
-                    print("Note: comet_mpm not installed; skipping MPM collection")
-                    continue
-            resolved.append(platform)
-        return resolved
-
-    def _resolve_workspaces(self, workspaces):
-        """Use the given `WORKSPACE` args if non-empty, else
-        `api.get_workspaces()`; apply `self.limit` once here so the final
-        workspace list is fixed before any collector runs (the collectors'
-        own `self.limit` slicing then becomes a no-op on this already-sliced
-        list -- not a double-slice)."""
-        resolved = (
-            list(workspaces) if workspaces else list(self.api.get_workspaces() or [])
-        )
-        resolved = self._filter_personal(resolved)
-        if self.limit is not None:
-            resolved = resolved[: self.limit]
-        return resolved
-
-    def _filter_personal(self, workspaces):
-        """Drop workspaces matching `self.personal_pattern` when
-        `self.exclude_personal` is set (Task 9). A no-op unless BOTH the
-        flag is on AND a pattern was supplied -- an on flag with no pattern
-        can't identify anything to drop, so it's a no-op too, with a
-        once-per-reporter warning since that combination is almost
-        certainly a user mistake (they meant to also pass
-        `--personal-pattern`). An invalid regex degrades the same way
-        (warn once, return unchanged) rather than crashing the whole run.
-        """
+    def _personal_pattern_compiled(self):
+        """Compiled --personal-pattern regex, or None (with a once-per-reporter
+        warning) when the flag is off, no pattern was given, or the pattern is
+        invalid."""
         if not self.exclude_personal:
-            return list(workspaces)
+            return None
         if not self.personal_pattern:
             if not self._warned_no_personal_pattern:
                 print(
@@ -557,9 +335,9 @@ class GrowthReporter:
                     "--personal-pattern; skipping personal-workspace exclusion"
                 )
                 self._warned_no_personal_pattern = True
-            return list(workspaces)
+            return None
         try:
-            pattern = re.compile(self.personal_pattern)
+            return re.compile(self.personal_pattern)
         except re.error as exc:
             if not self._warned_no_personal_pattern:
                 print(
@@ -568,31 +346,20 @@ class GrowthReporter:
                     "personal-workspace exclusion"
                 )
                 self._warned_no_personal_pattern = True
-            return list(workspaces)
-        return [ws for ws in workspaces if not pattern.search(ws)]
+            return None
 
-    _COLLECTOR_METHODS = {
-        "em": "_collect_em",
-        "opik": "_collect_opik",
-        "mpm": "_collect_mpm",
-    }
-
-    def _collect_selected(self, platforms, workspaces):
-        """Run each selected platform's collector and aggregate all events +
-        usage. Returns `(events, usage, ran)` where `ran` is a
-        `{"opik": bool, "em": bool, "mpm": bool}` map of which collectors
-        actually executed."""
-        events: list = []
-        usage: list = []
-        ran = {"opik": False, "em": False, "mpm": False}
-        for platform in platforms:
-            print(f"[{PLATFORM_LABELS.get(platform, platform)}] collecting...")
-            collector = getattr(self, self._COLLECTOR_METHODS[platform])
-            platform_events, platform_usage = collector(workspaces)
-            events.extend(platform_events)
-            usage.extend(platform_usage)
-            ran[platform] = True
-        return events, usage, ran
+    def _filter_personal_chargeback(self, chargeback):
+        """Drop personal workspaces (name matches --personal-pattern) from the
+        chargeback workspace list when --exclude-personal is set. The user
+        roster (users.report / licensedUsers) is left whole; only the
+        workspace list and its memberships are trimmed. Returns a shallow copy;
+        never mutates the input."""
+        pattern = self._personal_pattern_compiled()
+        if pattern is None:
+            return chargeback
+        workspaces = chargeback.get("workspaces") or []
+        kept = [w for w in workspaces if not pattern.search(w.get("name") or "")]
+        return {**chargeback, "workspaces": kept}
 
     def _window_label(self, window):
         return (
@@ -609,84 +376,6 @@ class GrowthReporter:
             "count_before": count_before,
             "window_start": format_time_key(window.start, window.units),
             "window_end": format_time_key(window.end, window.units),
-        }
-
-    def _series_chart_data(self, events, window):
-        """All-time zero-filled `(points, window_start, window_end)` for a
-        single-series bar/area chart, per Option-A window rendering."""
-        counts = _all_time_counts(events, self.units)
-        points = [
-            {"key": k, "value": v} for k, v in continuous_series(counts, self.units)
-        ]
-        window_start = format_time_key(window.start, self.units)
-        window_end = format_time_key(window.end, self.units)
-        return points, window_start, window_end
-
-    def _growth_kpis(self, stats, count_before, workspaces_count):
-        spec = self.window or "7d"
-        return [
-            {"label": "Workspaces", "value": workspaces_count},
-            {"label": "Total", "value": stats["total"]},
-            {"label": f"New ({spec})", "value": f"+{stats['new_in_window']}"},
-            {
-                "label": f"Growth ({spec})",
-                "value": f"{stats['pct_growth']}%",
-                "sub": f"vs {count_before} before window",
-            },
-        ]
-
-    def _breakdown_table(self, events, kind_label, workspaces_count):
-        """Apply the workspace-vs-use-case breakdown rule: more than one
-        workspace -> break down by workspace; a single workspace -> break
-        down by use case instead (a by-workspace table would have exactly
-        one, uninformative, row)."""
-        if workspaces_count > 1:
-            by_ws: dict = defaultdict(int)
-            for ev in events:
-                by_ws[ev.workspace] += 1
-            rows = sorted(by_ws.items(), key=lambda kv: -kv[1])
-            return {
-                "title": f"{kind_label} by workspace",
-                "headers": ["Workspace", kind_label],
-                "rows": [[ws, count] for ws, count in rows],
-            }
-        rows = sorted(events, key=lambda ev: ev.created, reverse=True)
-        return {
-            "title": kind_label,
-            "headers": ["Project", "Created"],
-            "rows": [[ev.use_case, ev.created.date().isoformat()] for ev in rows],
-        }
-
-    def _unified_table(self, events, workspaces_count):
-        if workspaces_count > 1:
-            by_ws = use_cases_by_workspace(events)
-            rows = sorted(by_ws.items(), key=lambda kv: -kv[1]["use_cases_total"])
-            return {
-                "title": "By workspace",
-                "headers": ["Workspace", "Opik", "EM", "MPM", "Total"],
-                "rows": [
-                    [
-                        ws,
-                        entry["by_kind"]["opik_project"],
-                        entry["by_kind"]["em_project"],
-                        entry["by_kind"]["mpm_model"],
-                        entry["use_cases_total"],
-                    ]
-                    for ws, entry in rows
-                ],
-            }
-        rows = sorted(unified_events(events), key=lambda ev: ev.created, reverse=True)
-        return {
-            "title": "Projects",
-            "headers": ["Project", "Kind", "Created"],
-            "rows": [
-                [
-                    ev.use_case,
-                    KIND_LABELS.get(ev.kind, ev.kind),
-                    ev.created.date().isoformat(),
-                ]
-                for ev in rows
-            ],
         }
 
     def _workspace_chargeback_table(self, ws_records):
@@ -707,138 +396,6 @@ class GrowthReporter:
                 for w in rows
             ],
         }
-
-    def _unified_stacked_chart(self, events, window):
-        events_by_kind = {
-            kind: [ev for ev in events if ev.kind == kind] for kind in USE_CASE_KINDS
-        }
-        points = _stacked_points(events_by_kind, self.units, USE_CASE_KINDS)
-        window_start = format_time_key(window.start, self.units) if points else None
-        window_end = format_time_key(window.end, self.units) if points else None
-        return {
-            "id": "chart-unified-created",
-            "kind": "stackedBars",
-            "title": "Projects created",
-            "hint": f"by kind · {self.units}ly",
-            "legend": [
-                {"label": "Opik", "color": "--accent"},
-                {"label": "EM", "color": "--sdk"},
-                {"label": "MPM", "color": "--ok"},
-            ],
-            "data": {
-                "categories": list(USE_CASE_KINDS),
-                "labels": {k: KIND_LABELS[k] for k in USE_CASE_KINDS},
-                "colors": ["--accent", "--sdk", "--ok"],
-                "points": points,
-                "window_start": window_start,
-                "window_end": window_end,
-            },
-        }
-
-    def _platform_stacked_chart(self, events, chart_id, title):
-        """Per-period stacked bars of `events` split by platform (Opik / EM /
-        MPM). Returns `None` when there are no events to bucket."""
-        platforms = ("opik", "em", "mpm")
-        by_platform = {p: [ev for ev in events if ev.platform == p] for p in platforms}
-        points = _stacked_points(by_platform, self.units, platforms)
-        if not points:
-            return None
-        return {
-            "id": chart_id,
-            "kind": "stackedBars",
-            "title": title,
-            "hint": f"by platform · {self.units}ly",
-            "legend": [
-                {"label": "Opik", "color": "--accent"},
-                {"label": "EM", "color": "--sdk"},
-                {"label": "MPM", "color": "--ok"},
-            ],
-            "data": {
-                "categories": list(platforms),
-                "labels": {p: PLATFORM_LABELS[p] for p in platforms},
-                "colors": ["--accent", "--sdk", "--ok"],
-                "points": points,
-                "window_start": None,
-                "window_end": None,
-            },
-        }
-
-    def _cumulative_area_chart(self, events, chart_id, title):
-        """Cumulative running-total area chart of `events`, bucketed by
-        `self.units` and zero-filled across all periods. Returns `None` with
-        fewer than two periods to plot (no trajectory to show)."""
-        counts = defaultdict(int)
-        for ev in events:
-            counts[format_time_key(ev.created, self.units)] += 1
-        cum = cumulative(continuous_series(counts, self.units))  # [(key, total)]
-        if len(cum) < 2:
-            return None
-        points = [{"key": key, "value": total} for key, total in cum]
-        return {
-            "id": chart_id,
-            "kind": "area",
-            "title": title,
-            "hint": f"cumulative · {self.units}ly",
-            "data": {
-                "points": points,
-                "window_start": None,
-                "window_end": None,
-            },
-        }
-
-    def _growth_rate_chart(self, events, chart_id, title):
-        """Period-over-period growth-RATE line: each period's new count divided
-        by the cumulative total at the start of the period (the recurring form
-        of the `pct_growth` KPI). WoW when `--units week`, MoM otherwise.
-        Returns `None` with fewer than two periods (a rate needs a prior
-        period). Note: on a small, lumpy population the rate is spiky (a single
-        addition can read as 100%); it smooths out with volume."""
-        counts = {}
-        for ev in events:
-            key = format_time_key(ev.created, self.units)
-            counts[key] = counts.get(key, 0) + 1
-        series = continuous_series(counts, self.units)  # [(key, new)]
-        if len(series) < 2:
-            return None
-        points = []
-        prev_total = 0
-        for key, new in series:
-            rate = round(new / prev_total * 100, 1) if prev_total else 0.0
-            points.append({"key": key, "values": {"rate": rate}})
-            prev_total += new
-        period = (
-            "week-over-week"
-            if self.units == "week"
-            else f"{self.units}-over-{self.units}"
-        )
-        return {
-            "id": chart_id,
-            "kind": "lines",
-            "title": f"{title} ({period})",
-            "hint": "new / cumulative total at start of period",
-            "legend": [{"label": "Growth rate", "color": "--accent"}],
-            "data": {
-                "categories": ["rate"],
-                "labels": {"rate": "Growth rate"},
-                "colors": ["--accent"],
-                "points": points,
-                "window_start": None,
-                "window_end": None,
-            },
-        }
-
-    @staticmethod
-    def _workspace_first_events(unified):
-        """One synthetic creation event per workspace, at the earliest
-        project-creation seen in it (its "created" proxy). Feeds the
-        workspace-level created / cumulative / growth views in the summary
-        section; each retains the platform of that earliest project."""
-        first = {}
-        for ev in unified:
-            cur = first.get(ev.workspace)
-            if cur is None or ev.created < cur.created:
-                first[ev.workspace] = ev
-        return list(first.values())
 
     @staticmethod
     def _workspace_growth_kpi(users, window):
@@ -865,57 +422,18 @@ class GrowthReporter:
 
     def _build_unified_section(
         self,
-        events,
         window,
-        workspaces_count,
         people_users=None,
         ws_records=None,
         now_ms=None,
         active_window_days=None,
     ):
-        """Top workspace-and-project section. When chargeback data is present
-        (`ws_records` / `people_users`), the KPIs and platform-mix are ORG-WIDE
-        from chargeback (workspaces, projects, experiments, active %); the
-        project/workspace *creation timelines* remain SDK-derived (accessible
-        workspaces only) since chargeback carries no creation dates. Every
-        workspace-level number lives here; the Users section stays about
-        users."""
-        unified = unified_events(events)
-        ws_events = self._workspace_first_events(unified)
-        proj_stats = growth_stats(unified, window, self.units)
-        ws_stats = growth_stats(ws_events, window, self.units)
-        spec = self.window or "7d"
-
-        # SDK-derived creation timelines (accessible workspaces only). These are
-        # the "project-based" charts; when chargeback is present they move to
-        # their per-product sections and this org section stays chargeback-only.
-        sdk_charts = [
-            self._platform_stacked_chart(
-                ws_events, "chart-unified-workspaces-created", "Workspaces created"
-            ),
-            self._cumulative_area_chart(
-                ws_events,
-                "chart-unified-workspaces-cumulative",
-                "Total workspaces over time",
-            ),
-            self._growth_rate_chart(
-                ws_events, "chart-unified-workspaces-rate", "Workspace growth rate"
-            ),
-            self._unified_stacked_chart(events, window),
-            self._cumulative_area_chart(
-                unified,
-                "chart-unified-projects-cumulative",
-                "Total projects over time",
-            ),
-            self._growth_rate_chart(
-                unified, "chart-unified-projects-rate", "Project growth rate"
-            ),
-        ]
-
-        # Chargeback-derived org-wide charts (total-vs-active, added/deleted,
-        # platform mix) — only when chargeback users/records are present.
+        """Organization overview (chargeback). Org-wide KPIs (workspaces,
+        projects, new-in-window %, active-workspaces %), the platform mix, and
+        the workspace total-vs-active / added-vs-deleted charts -- all derived
+        from the chargeback report. Every workspace-level number lives here; the
+        Users section stays about users."""
         cb_charts = []
-        ws_kpi_extra = []
         if people_users:
             ws_active_pts = workspace_active_series(
                 people_users, self.units, now_ms, active_window_days
@@ -992,14 +510,6 @@ class GrowthReporter:
                         },
                     }
                 )
-            wa = workspace_active_stats(people_users, now_ms, active_window_days)
-            ws_kpi_extra.append(
-                {
-                    "label": "Active workspaces %",
-                    "value": f"{wa['active_pct']}%",
-                    "sub": f"{wa['active']}/{wa['total']} active",
-                }
-            )
 
         # Org-wide platform mix (chargeback): EM-only / Opik-only / both /
         # neither. MPM is not in chargeback, so it's excluded; Opik is a
@@ -1026,315 +536,42 @@ class GrowthReporter:
                 }
             )
 
-        if ws_records:
-            # ORGANIZATION OVERVIEW (chargeback): org-wide headline numbers and
-            # chargeback-derived charts only. The SDK creation timelines move to
-            # their per-product growth sections.
-            org = workspace_org_totals(ws_records)
-            wa = workspace_active_stats(
-                people_users or [],
-                now_ms,
-                active_window_days,
-                all_workspaces={w.name for w in ws_records},
-            )
-            wg = self._workspace_growth_kpi(people_users or [], window)
-            kpis = [
-                {"label": "Total workspaces", "value": org["workspaces"]},
-                {
-                    "label": "Total projects",
-                    "value": org["projects"],
-                    "sub": "EM projects",
-                    "tone": "ok",
-                },
-                {
-                    "label": f"New in {spec} (% of base)",
-                    "value": f"{wg['pct']}%",
-                    "sub": f"+{wg['new_in']} new",
-                },
-                {
-                    "label": "Active workspaces %",
-                    "value": f"{wa['active_pct']}%",
-                    "sub": f"{wa['active']}/{wa['total']} active",
-                },
-            ]
-            return {
-                "title": "Organization overview (chargeback)",
-                "window_chip": self._window_label(window),
-                "kpis": kpis,
-                "charts": [c for c in cb_charts if c],
-                "table": self._workspace_chargeback_table(ws_records),
-            }
-
-        # No chargeback -> SDK-only fallback (accessible workspaces): keep the
-        # creation timelines and SDK headline here.
-        kpis = [{"label": "Total workspaces", "value": workspaces_count}]
-        kpis += ws_kpi_extra
-        kpis += [
-            {"label": "Total projects", "value": proj_stats["total"], "tone": "ok"},
-            {
-                "label": f"New workspaces in {spec} (% of base)",
-                "value": f"{ws_stats['pct_growth']}%",
-                "sub": f"+{ws_stats['new_in_window']} new",
-            },
-            {
-                "label": f"New projects in {spec} (% of base)",
-                "value": f"{proj_stats['pct_growth']}%",
-                "sub": f"+{proj_stats['new_in_window']} new",
-            },
-        ]
-        return {
-            "title": "Workspaces & projects (accessible)",
-            "window_chip": self._window_label(window),
-            "kpis": kpis,
-            "charts": [c for c in (sdk_charts + cb_charts) if c],
-            "table": self._unified_table(events, workspaces_count),
-        }
-
-    def _adoption_metric_series(self, metric_name, metrics, window):
-        """Combine the per-workspace-total entries (`project is None`) for
-        `metric_name` into one all-time zero-filled series + grand total."""
-        ws_totals = [
-            m for m in metrics if m.metric == metric_name and m.project is None
-        ]
-        total = sum(m.value for m in ws_totals)
-        merged: dict = defaultdict(float)
-        for m in ws_totals:
-            for key, value in m.series or []:
-                merged[key] += value
-        points = (
-            [
-                {"key": k, "value": v}
-                for k, v in continuous_series(dict(merged), self.units)
-            ]
-            if merged
-            else []
+        # ORGANIZATION OVERVIEW (chargeback): org-wide headline numbers +
+        # chargeback-derived charts. Degrades to zeros if ws_records is empty.
+        ws_records = ws_records or []
+        org = workspace_org_totals(ws_records)
+        wa = workspace_active_stats(
+            people_users or [],
+            now_ms,
+            active_window_days,
+            all_workspaces={w.name for w in ws_records},
         )
-        window_start = format_time_key(window.start, self.units)
-        window_end = format_time_key(window.end, self.units)
-        return _num(total), points, window_start, window_end
-
-    def _adoption_table_by_project(self, metric_name, metrics, value_label):
-        project_metrics = [
-            m for m in metrics if m.metric == metric_name and m.project is not None
-        ]
-        rows = sorted(project_metrics, key=lambda m: -m.value)
-        return {
-            "title": f"{value_label} by project",
-            "headers": ["Project", value_label],
-            "rows": [[m.project, _num(m.value)] for m in rows],
-        }
-
-    def _registry_panel(self, usage):
-        models = {m.workspace: m.value for m in usage if m.metric == "REGISTRY_MODELS"}
-        versions = {
-            m.workspace: m.value for m in usage if m.metric == "REGISTRY_VERSIONS"
-        }
-        workspaces = sorted(set(models) | set(versions))
-        return {
-            "title": "Model-registry engagement",
-            "hint": "snapshot, not over-time",
-            "headers": ["Workspace", "Registered models", "Model versions"],
-            "rows": [
-                [ws, _num(models.get(ws, 0)), _num(versions.get(ws, 0))]
-                for ws in workspaces
-            ],
-        }
-
-    def _series_window_stats(self, points, window_start, window_end):
-        """Growth of a per-period value series over the window. Bucket keys
-        are zero-padded and lexicographically sortable, so window membership
-        is a string comparison. Returns total / new_in_window / before /
-        pct_growth (0-guarded), mirroring `growth_stats` for value series."""
-        total = new_in = before = 0.0
-        for p in points:
-            key, value = p.get("key"), p.get("value", 0) or 0
-            total += value
-            if window_start <= key <= window_end:
-                new_in += value
-            elif key < window_start:
-                before += value
-        pct = (new_in / before * 100.0) if before > 0 else 0.0
-        return {
-            "total": total,
-            "new_in_window": new_in,
-            "before": before,
-            "pct_growth": round(pct, 1),
-        }
-
-    def _fastest_growing_project(self, metric_name, metrics, window_start, window_end):
-        """The project with the largest in-window increase for `metric_name`
-        (absolute new-in-window, which is robust to tiny-base % noise).
-        Returns (project, new_in_window) or None if nothing grew in-window."""
-        best = None
-        for m in metrics:
-            if m.metric != metric_name or m.project is None:
-                continue
-            new_in = sum(
-                value
-                for key, value in (m.series or [])
-                if window_start <= key <= window_end
-            )
-            if new_in > 0 and (best is None or new_in > best[1]):
-                best = (m.project, new_in)
-        return best
-
-    def _build_adoption_section(self, platform, usage, window):
-        """Per-product adoption/usage section. Registry counts (EM) are
-        NEVER merged with MPM's monitored-model metrics -- they live in
-        their own `panels` entry with distinct labels."""
-        if platform == "opik":
-            metric, value_label = "SPAN_COUNT", "Span count"
-        elif platform == "em":
-            metric, value_label = "EXPERIMENT_COUNT", "Experiment count"
-        else:
-            metric, value_label = "PREDICTION_VOLUME", "Prediction volume"
-
-        total, points, window_start, window_end = self._adoption_metric_series(
-            metric, usage, window
-        )
-        stats = self._series_window_stats(points, window_start, window_end)
-        spec = self.window or "7d"
-
-        # Usage growth KPIs (not just the total), plus the fastest-growing
-        # project so a bare "total" section reads as a trend.
+        wg = self._workspace_growth_kpi(people_users or [], window)
         kpis = [
-            {"label": value_label, "value": _num(total)},
-            {"label": f"New ({spec})", "value": f"+{_num(stats['new_in_window'])}"},
+            {"label": "Total workspaces", "value": org["workspaces"]},
             {
-                "label": f"Growth ({spec})",
-                "value": f"{stats['pct_growth']}%",
-                "sub": f"vs {_num(stats['before'])} before window",
+                "label": "Total projects",
+                "value": org["projects"],
+                "sub": "EM projects",
+                "tone": "ok",
+            },
+            {
+                "label": f"New in {self.window or '7d'} (% of base)",
+                "value": f"{wg['pct']}%",
+                "sub": f"+{wg['new_in']} new",
+            },
+            {
+                "label": "Active workspaces %",
+                "value": f"{wa['active_pct']}%",
+                "sub": f"{wa['active']}/{wa['total']} active",
             },
         ]
-        # Always surface the fastest-growing project (for every product,
-        # incl. EM = most new experiments in the window); "-" when nothing
-        # grew in-window so the KPI is consistently present, not missing.
-        fastest = self._fastest_growing_project(metric, usage, window_start, window_end)
-        if fastest:
-            kpis.append(
-                {
-                    "label": "Fastest-growing project",
-                    "value": fastest[0],
-                    "sub": f"+{_num(fastest[1])} in window",
-                }
-            )
-        else:
-            kpis.append(
-                {
-                    "label": "Fastest-growing project",
-                    "value": "—",
-                    "sub": "no activity in window",
-                }
-            )
-
-        charts = []
-        if points:
-            charts.append(
-                {
-                    "id": f"chart-{platform}-adoption",
-                    "kind": "bars",
-                    "title": f"{value_label} — new per period",
-                    "hint": f"by {self.units}",
-                    "data": {
-                        "points": points,
-                        "window_start": window_start,
-                        "window_end": window_end,
-                    },
-                }
-            )
-            cum_points = [
-                {"key": k, "value": v}
-                for k, v in cumulative([(p["key"], p["value"]) for p in points])
-            ]
-            charts.append(
-                {
-                    "id": f"chart-{platform}-adoption-cumulative",
-                    "kind": "area",
-                    "title": f"{value_label} — cumulative",
-                    "hint": "all-time",
-                    "data": {
-                        "points": cum_points,
-                        "window_start": window_start,
-                        "window_end": window_end,
-                        "delta": _num(stats["new_in_window"]),
-                    },
-                }
-            )
-
-        section = {
-            "title": f"{PLATFORM_LABELS[platform]} — adoption / usage",
-            "kpis": kpis,
-            "charts": charts,
-            "table": self._adoption_table_by_project(metric, usage, value_label),
-        }
-        if platform == "em":
-            registry_panel = self._registry_panel(usage)
-            section["panels"] = [registry_panel] if registry_panel["rows"] else []
-        return section
-
-    def _build_product_section(
-        self, platform, kind, events, usage, window, workspaces_count
-    ):
-        kind_events = [ev for ev in events if ev.kind == kind]
-        stats = growth_stats(kind_events, window, self.units)
-        count_before = sum(1 for ev in kind_events if ev.created < window.start)
-        workspaces_with_kind = {ev.workspace for ev in kind_events}
-
-        points, window_start, window_end = self._series_chart_data(kind_events, window)
-        cum_points = [
-            {"key": k, "value": v}
-            for k, v in cumulative(
-                continuous_series(_all_time_counts(kind_events, self.units), self.units)
-            )
-        ]
-
-        growth_section = {
-            "title": f"{PLATFORM_LABELS[platform]} — growth",
-            "window_chip": self._window_label(window),
-            "kpis": self._growth_kpis(stats, count_before, len(workspaces_with_kind)),
-            "charts": [
-                chart
-                for chart in (
-                    {
-                        "id": f"chart-{platform}-bars",
-                        "kind": "bars",
-                        "title": f"New {KIND_LABELS[kind]}",
-                        "hint": f"by {self.units}",
-                        "data": {
-                            "points": points,
-                            "window_start": window_start,
-                            "window_end": window_end,
-                        },
-                    },
-                    {
-                        "id": f"chart-{platform}-area",
-                        "kind": "area",
-                        "title": f"{KIND_LABELS[kind]} — cumulative",
-                        "hint": "all-time",
-                        "data": {
-                            "points": cum_points,
-                            "window_start": window_start,
-                            "window_end": window_end,
-                            "delta": stats["new_in_window"],
-                        },
-                    },
-                    self._growth_rate_chart(
-                        kind_events,
-                        f"chart-{platform}-rate",
-                        f"{KIND_LABELS[kind]} growth rate",
-                    ),
-                )
-                if chart
-            ],
-            "table": self._breakdown_table(
-                kind_events, KIND_LABELS[kind], workspaces_count
-            ),
-        }
-
         return {
-            "label": PLATFORM_LABELS[platform],
-            "growth": growth_section,
-            "adoption": self._build_adoption_section(platform, usage, window),
+            "title": "Organization overview (chargeback)",
+            "window_chip": self._window_label(window),
+            "kpis": kpis,
+            "charts": [c for c in cb_charts if c],
+            "table": self._workspace_chargeback_table(ws_records),
         }
 
     def _active_window_days(self, now):
@@ -1623,18 +860,14 @@ class GrowthReporter:
                 totals[ws] = totals.get(ws, 0) + value
         return totals
 
-    def _build_leaderboards_section(self, usage, users, ran, ws_records=None):
-        """Top-N / bottom-N workspace and user leaderboards.
-
-        Experiments and projects are ranked ORG-WIDE and EXACTLY from the
-        chargeback per-workspace numbers (`ws_records`) when available, else
-        from the SDK (accessible workspaces). Opik spans are org-wide from the
-        chargeback per-user rollup (a proxy: a member's spans are attributed to
-        each of their workspaces), else SDK. Traces and predictions have no
-        per-user/per-workspace chargeback field, so they stay SDK-sourced
-        (accessible workspaces only). Bottom-N is active-aware
-        (strictly-positive, ascending). Empty metrics are omitted; returns
-        `None` when there is nothing to show."""
+    def _build_leaderboards_section(self, users, ws_records):
+        """Top-N / bottom-N workspace and user leaderboards, all org-wide from
+        chargeback. Experiments and projects are ranked EXACTLY from the
+        chargeback per-workspace numbers; Opik spans from the chargeback
+        per-user rollup (a proxy: a member's spans are attributed to each of
+        their workspaces). Bottom-N is active-aware (strictly-positive,
+        ascending). Empty metrics are omitted; returns `None` when there is
+        nothing to show."""
         n = self.leaderboard_top_n
         charts = []
 
@@ -1666,22 +899,13 @@ class GrowthReporter:
                     )
                 )
 
-        def sdk_totals(platform, metric):
-            return {
-                m.workspace: m.value
-                for m in usage
-                if m.platform == platform and m.metric == metric and m.project is None
-            }
-
         org_exact_hint = "org-wide, exact (chargeback per-workspace)"
         org_proxy_hint = (
             "org-wide from chargeback; per-user spans attributed to each of "
             "the user's workspaces (proxy)"
         )
-        sdk_hint = "accessible workspaces only (SDK)"
 
-        # Experiments + projects: exact, org-wide from chargeback per-workspace
-        # numbers when available, else SDK (accessible workspaces).
+        # Experiments + projects: exact, org-wide from chargeback per-workspace.
         if ws_records:
             emit_ws(
                 "ws-experiments",
@@ -1695,39 +919,14 @@ class GrowthReporter:
                 {w.name: w.num_projects for w in ws_records if w.num_projects},
                 org_exact_hint,
             )
-        elif ran.get("em"):
-            emit_ws(
-                "em-experiment_count",
-                "experiments",
-                sdk_totals("em", "EXPERIMENT_COUNT"),
-                sdk_hint,
-            )
 
-        # Opik spans: org-wide per-user rollup proxy when users present, else SDK.
+        # Opik spans: org-wide per-user rollup proxy.
         if users:
             emit_ws(
                 "ws-spans",
                 "Opik spans",
                 self._workspace_rollup(users, lambda u: u.opik_span_count or 0),
                 org_proxy_hint,
-            )
-        elif ran.get("opik"):
-            emit_ws(
-                "opik-span_count",
-                "Opik spans",
-                sdk_totals("opik", "SPAN_COUNT"),
-                sdk_hint,
-            )
-
-        # Predictions have no per-user chargeback field -> SDK only. (The
-        # workspace-by-traces board was removed: traces aren't a useful
-        # per-workspace ranking here and are SDK/accessible-only anyway.)
-        if ran.get("mpm"):
-            emit_ws(
-                "mpm-prediction_volume",
-                "predictions",
-                sdk_totals("mpm", "PREDICTION_VOLUME"),
-                sdk_hint,
             )
 
         if users:
@@ -1820,102 +1019,52 @@ class GrowthReporter:
         }
 
     @staticmethod
-    def _scope_label(scope, sdk_count, org_workspaces, org_users, has_chargeback):
+    def _scope_label(scope, org_workspaces, org_users):
         """One-line scope descriptor for the report header."""
         if scope is not None:
-            return f"Scoped to {sdk_count} selected workspace(s)"
-        if has_chargeback and org_workspaces is not None:
+            return f"Scoped to {len(scope)} selected workspace(s)"
+        if org_workspaces is not None:
             return (
                 f"Org-wide: {org_workspaces} workspaces, {org_users} users "
-                f"(project & growth metrics cover {sdk_count} workspace(s) "
-                "accessible to this key)"
+                "(chargeback)"
             )
-        return f"Workspaces accessible to this key: {sdk_count}"
+        return "Org-wide (chargeback)"
 
-    def _assemble_report_data(
-        self,
-        events,
-        usage,
-        ran,
-        workspaces,
-        window,
-        chargeback=None,
-        now_ms=None,
-        scope=None,
-    ):
-        workspaces_count = len(workspaces)
-
-        # Org totals from the FULL (unscoped) chargeback, for the header label.
-        # Use the SAME definitions as the section KPIs so header and KPIs never
-        # disagree: total workspaces = the chargeback workspace-list count (the
-        # authoritative "Total workspaces"); users = non-suspended count.
+    def _assemble_report_data(self, chargeback, window, now_ms, scope=None):
+        # Org totals for the header, from the FULL (unscoped) chargeback.
         org_users = org_workspaces = None
-        if chargeback:
-            try:
-                org_users = sum(1 for u in parse_users(chargeback) if not u.suspended)
-                org_workspaces = len(parse_workspaces(chargeback))
-            except Exception:
-                # Malformed chargeback: fall back to a scope label without org
-                # totals; the section builders below degrade independently.
-                org_users = org_workspaces = None
+        try:
+            org_users = sum(1 for u in parse_users(chargeback) if not u.suspended)
+            org_workspaces = len(parse_workspaces(chargeback))
+        except Exception:
+            org_users = org_workspaces = None
 
-        # The chargeback layers are org-wide by default; when the caller passed
-        # an explicit workspace set, scope them down to match the SDK summary.
-        scoped_chargeback = chargeback
-        if chargeback and scope is not None:
-            scoped_chargeback = _scope_chargeback(chargeback, scope)
-
-        # Parse the (scoped) chargeback users once; feed the workspace-level
-        # chargeback metrics into the Workspaces & projects section and the
-        # user-level metrics into the Users section + leaderboards.
-        people_users = []
-        ws_records = []
-        active_window_days = None
-        if scoped_chargeback:
-            active_window_days = self._active_window_days(_ms_to_utc(now_ms))
-            try:
-                people_users = parse_users(scoped_chargeback)
-                ws_records = parse_workspaces(scoped_chargeback)
-            except Exception as exc:
-                print(
-                    f"Warning: failed to parse chargeback report; "
-                    f"skipping org layers: {_short_api_error(exc)}"
-                )
-                people_users = []
-                ws_records = []
-
-        unified_section = self._build_unified_section(
-            events,
-            window,
-            workspaces_count,
-            people_users=people_users,
-            ws_records=ws_records,
-            now_ms=now_ms,
-            active_window_days=active_window_days,
-        )
-        count_before_unified = sum(
-            1 for ev in unified_events(events) if ev.created < window.start
+        scoped = (
+            _scope_chargeback(chargeback, scope) if scope is not None else chargeback
         )
 
-        kind_by_platform = {
-            "opik": "opik_project",
-            "em": "em_project",
-            "mpm": "mpm_model",
-        }
-        products = {}
-        for platform in ("opik", "em", "mpm"):
-            if not ran.get(platform):
-                continue
-            products[platform] = self._build_product_section(
-                platform,
-                kind_by_platform[platform],
-                events,
-                usage,
-                window,
-                workspaces_count,
+        active_window_days = self._active_window_days(_ms_to_utc(now_ms))
+        try:
+            people_users = parse_users(scoped)
+            ws_records = parse_workspaces(scoped)
+        except Exception as exc:
+            print(
+                f"Warning: failed to parse chargeback report: "
+                f"{_short_api_error(exc)}"
             )
+            people_users = []
+            ws_records = []
 
-        sections = {"unified": unified_section, "products": products}
+        sections = {
+            "unified": self._build_unified_section(
+                window,
+                people_users=people_users,
+                ws_records=ws_records,
+                now_ms=now_ms,
+                active_window_days=active_window_days,
+            )
+        }
+
         if people_users:
             try:
                 people_section = self._build_people_section(
@@ -1923,8 +1072,8 @@ class GrowthReporter:
                 )
             except Exception as exc:
                 print(
-                    f"Warning: failed to build users section from chargeback data; "
-                    f"skipping: {_short_api_error(exc)}"
+                    f"Warning: failed to build users section: "
+                    f"{_short_api_error(exc)}"
                 )
                 people_section = None
             if people_section:
@@ -1932,7 +1081,7 @@ class GrowthReporter:
 
         try:
             leaderboards_section = self._build_leaderboards_section(
-                usage, people_users, ran, ws_records=ws_records
+                people_users, ws_records
             )
         except Exception as exc:
             print(f"Warning: failed to build leaderboards section; skipping: {exc}")
@@ -1965,561 +1114,12 @@ class GrowthReporter:
             "meta": {
                 "title": "Comet growth report",
                 "generated": window.end.isoformat(),
-                "source": "Comet Admin API",
-                "scope": self._scope_label(
-                    scope,
-                    workspaces_count,
-                    org_workspaces,
-                    org_users,
-                    bool(chargeback),
-                ),
+                "source": "Comet Admin API (chargeback)",
+                "scope": self._scope_label(scope, org_workspaces, org_users),
             },
-            "window": self._build_window_block(window, count_before_unified),
-            "collectors": ran,
+            "window": self._build_window_block(window, 0),
             "sections": sections,
         }
-
-    def _workspace_usage_metric(self, platform, metric, workspace, value, counts):
-        """Build the workspace-level (`project=None`) summary `UsageMetric`
-        appended by every collector, so the summary shape lives in one place
-        instead of being duplicated across EM/Opik/MPM."""
-        return UsageMetric(
-            platform=platform,
-            workspace=workspace,
-            metric=metric,
-            value=value,
-            project=None,
-            series=(continuous_series(dict(counts), self.units) if counts else []),
-        )
-
-    def _collect_em(self, workspaces):
-        """Collect EM `em_project` CreationEvents + EXPERIMENT_COUNT /
-        REGISTRY_MODELS / REGISTRY_VERSIONS UsageMetrics.
-
-        EM projects have no creation timestamp, so `created` is resolved via
-        a proxy chain (see task-C4-context.md): probe a creation-timestamp
-        key on the project json -> earliest experiment
-        `start_server_timestamp` -> `lastUpdated`. This is ALL-TIME data;
-        `self.window` is not applied here (that happens later for KPIs).
-        """
-        events: list = []
-        usage: list = []
-
-        if self.limit is not None:
-            workspaces = list(workspaces)[: self.limit]
-
-        for ws in tqdm(list(workspaces), desc="EM workspaces", unit="ws"):
-            try:
-                response = self.api._client.get_from_endpoint(
-                    "projects", {"workspaceName": ws}
-                )
-                projects = (response or {}).get("projects", []) or []
-            except Exception as exc:
-                print(f"Note: skipping EM for workspace {ws}: {_short_api_error(exc)}")
-                continue
-
-            # The EM `projects` endpoint returns a FALLBACK set (projects from
-            # another workspace) when the API key isn't a member of `ws`,
-            # ignoring the requested workspaceName. Keep only projects whose
-            # own `workspaceName` actually matches `ws` so those fallback
-            # projects aren't mis-attributed here. The workspace is still
-            # reported (with a 0 experiment total below) rather than dropped.
-            matched = [p for p in projects if p.get("workspaceName") == ws]
-            dropped = len(projects) - len(matched)
-            if dropped:
-                print(
-                    f"Warning: EM projects endpoint returned {dropped} project(s) "
-                    f"not belonging to workspace {ws} (API key likely lacks EM "
-                    f"access there); skipping them and reporting {ws} at 0."
-                )
-            projects = matched
-
-            ws_experiment_total = 0
-            ws_counts: dict = defaultdict(int)
-
-            for project in tqdm(projects, desc=f"EM {ws}", unit="proj", leave=False):
-                proj_name = project.get("projectName")
-                try:
-                    # Fetch the project's experiments once and reuse the list
-                    # for both the creation proxy and the over-time series.
-                    experiments = self.api.get_experiments(ws, proj_name) or []
-                    created = self._em_project_created(project, experiments)
-                    counts = self._em_experiment_counts(experiments)
-                    # Derive the KPI total from the SAME bucketed counts that
-                    # feed the chart series -- NOT the `numberOfExperiments`
-                    # metadata, which can disagree with the experiments that
-                    # actually carry a `start_server_timestamp`. This keeps the
-                    # EM adoption KPI total (and its workspace roll-up) exactly
-                    # equal to the cumulative chart sum.
-                    total = sum(counts.values())
-
-                    events.append(
-                        CreationEvent(
-                            platform="em",
-                            workspace=ws,
-                            use_case=proj_name,
-                            kind="em_project",
-                            created=created,
-                        )
-                    )
-                    usage.append(
-                        UsageMetric(
-                            platform="em",
-                            workspace=ws,
-                            metric="EXPERIMENT_COUNT",
-                            value=total,
-                            project=proj_name,
-                            series=(
-                                continuous_series(counts, self.units) if counts else []
-                            ),
-                        )
-                    )
-                    ws_experiment_total += total
-                    for key, n in counts.items():
-                        ws_counts[key] += n
-                except Exception as exc:
-                    print(
-                        f"Warning: failed to collect EM project "
-                        f"{ws}/{proj_name}: {exc}"
-                    )
-                    continue
-
-            usage.append(
-                self._workspace_usage_metric(
-                    "em", "EXPERIMENT_COUNT", ws, ws_experiment_total, ws_counts
-                )
-            )
-
-            try:
-                model_names = self.api.get_registry_model_names(ws) or []
-                version_total = sum(
-                    len(self.api.get_registry_model_versions(ws, name) or [])
-                    for name in model_names
-                )
-                usage.append(
-                    UsageMetric(
-                        platform="em",
-                        workspace=ws,
-                        metric="REGISTRY_MODELS",
-                        value=len(model_names),
-                        project=None,
-                        series=None,
-                    )
-                )
-                usage.append(
-                    UsageMetric(
-                        platform="em",
-                        workspace=ws,
-                        metric="REGISTRY_VERSIONS",
-                        value=version_total,
-                        project=None,
-                        series=None,
-                    )
-                )
-            except Exception as exc:
-                print(
-                    f"Warning: failed to collect EM registry stats for {ws}: "
-                    f"{_short_api_error(exc)}"
-                )
-
-        return events, usage
-
-    def _em_project_created(self, project, experiments):
-        """Resolve an EM project's creation time via the documented proxy
-        chain: creation-timestamp key (future-proof, currently absent) ->
-        earliest experiment start_server_timestamp -> lastUpdated.
-
-        `experiments` is the pre-fetched experiment list for the project
-        (fetched once by the caller and shared with `_em_experiment_counts`).
-        """
-        for key in ("createdAt", "creationDate", "creationDateMillis"):
-            ms = project.get(key)
-            if ms:
-                return _ms_to_utc(ms)
-
-        starts = [
-            exp.start_server_timestamp
-            for exp in experiments
-            if getattr(exp, "start_server_timestamp", None)
-        ]
-        if starts:
-            return _ms_to_utc(min(starts))
-
-        return _ms_to_utc(project.get("lastUpdated"))
-
-    def _collect_opik(self, workspaces):
-        """Collect Opik `opik_project` CreationEvents + SPAN_COUNT
-        UsageMetrics.
-
-        This is ALL-TIME data (interval_start=project.created_at,
-        interval_end=now); `self.window` is not applied here (that happens
-        later for KPIs). Degrades gracefully to `([], [])` if `opik` is not
-        installed.
-        """
-        try:
-            import opik
-        except ImportError:
-            print("Warning: opik not installed; skipping Opik collection")
-            return [], []
-
-        from cometx.cli.smoke_test import get_opik_config
-
-        events: list = []
-        usage: list = []
-
-        if self.limit is not None:
-            workspaces = list(workspaces)[: self.limit]
-
-        api_key = self.api.config["comet.api_key"]
-        comet_base_url = self.api.config["comet.url_override"].rstrip("/")
-        host = get_opik_config(comet_base_url)
-
-        interval = {
-            "hour": "HOURLY",
-            "day": "DAILY",
-            "week": "WEEKLY",
-            "month": "WEEKLY",
-        }.get(self.units, "WEEKLY")
-
-        now = datetime.datetime.now(datetime.timezone.utc)
-
-        for ws in tqdm(list(workspaces), desc="Opik workspaces", unit="ws"):
-            try:
-                client = opik.Opik(workspace=ws, api_key=api_key, host=host)
-            except Exception as exc:
-                print(
-                    f"Note: skipping Opik for workspace {ws}: "
-                    f"{_short_api_error(exc)}"
-                )
-                continue
-
-            try:
-                projects = []
-                page_num = 1
-                while True:
-                    page = client.rest_client.projects.find_projects(
-                        page=page_num, size=100
-                    )
-                    content = page.content or []
-                    projects.extend(content)
-                    if not content or len(projects) >= page.total:
-                        break
-                    page_num += 1
-            except Exception as exc:
-                print(
-                    f"Note: skipping Opik for workspace {ws}: "
-                    f"{_short_api_error(exc)}"
-                )
-                continue
-
-            ws_counts: dict = defaultdict(float)
-            ws_trace_counts: dict = defaultdict(float)
-
-            for project in tqdm(projects, desc=f"Opik {ws}", unit="proj", leave=False):
-                try:
-                    if project.created_at is not None:
-                        events.append(
-                            CreationEvent(
-                                platform="opik",
-                                workspace=ws,
-                                use_case=project.name,
-                                kind="opik_project",
-                                created=project.created_at,
-                            )
-                        )
-
-                    interval_start = project.created_at or datetime.datetime(
-                        1970, 1, 1, tzinfo=datetime.timezone.utc
-                    )
-                    resp = client.rest_client.projects.get_project_metrics(
-                        project.id,
-                        metric_type="SPAN_COUNT",
-                        interval=interval,
-                        interval_start=interval_start,
-                        interval_end=now,
-                    )
-                    counts: dict = defaultdict(float)
-                    for result in resp.results or []:
-                        for dp in result.data or []:
-                            counts[format_time_key(dp.time, self.units)] += _as_float(
-                                dp.value
-                            )
-
-                    usage.append(
-                        UsageMetric(
-                            platform="opik",
-                            workspace=ws,
-                            metric="SPAN_COUNT",
-                            value=sum(counts.values()),
-                            project=project.name,
-                            series=(
-                                continuous_series(dict(counts), self.units)
-                                if counts
-                                else []
-                            ),
-                        )
-                    )
-                    for key, val in counts.items():
-                        ws_counts[key] += val
-
-                    try:
-                        trace_resp = client.rest_client.projects.get_project_metrics(
-                            project.id,
-                            metric_type="TRACE_COUNT",
-                            interval=interval,
-                            interval_start=interval_start,
-                            interval_end=now,
-                        )
-                        trace_counts: dict = defaultdict(float)
-                        for result in trace_resp.results or []:
-                            for dp in result.data or []:
-                                trace_counts[
-                                    format_time_key(dp.time, self.units)
-                                ] += _as_float(dp.value)
-
-                        usage.append(
-                            UsageMetric(
-                                platform="opik",
-                                workspace=ws,
-                                metric="TRACE_COUNT",
-                                value=sum(trace_counts.values()),
-                                project=project.name,
-                                series=(
-                                    continuous_series(dict(trace_counts), self.units)
-                                    if trace_counts
-                                    else []
-                                ),
-                            )
-                        )
-                        for key, val in trace_counts.items():
-                            ws_trace_counts[key] += val
-                    except Exception as exc:
-                        print(
-                            f"Warning: failed to collect Opik TRACE_COUNT for "
-                            f"{ws}/{getattr(project, 'name', '?')}: "
-                            f"{_short_api_error(exc)}"
-                        )
-                except Exception as exc:
-                    print(
-                        f"Warning: failed to collect Opik project "
-                        f"{ws}/{getattr(project, 'name', '?')}: "
-                        f"{_short_api_error(exc)}"
-                    )
-                    continue
-
-            usage.append(
-                self._workspace_usage_metric(
-                    "opik", "SPAN_COUNT", ws, sum(ws_counts.values()), ws_counts
-                )
-            )
-            usage.append(
-                self._workspace_usage_metric(
-                    "opik",
-                    "TRACE_COUNT",
-                    ws,
-                    sum(ws_trace_counts.values()),
-                    ws_trace_counts,
-                )
-            )
-
-        return events, usage
-
-    def _collect_mpm(self, workspaces):
-        """Collect MPM `mpm_model` CreationEvents + PREDICTION_VOLUME
-        UsageMetrics.
-
-        MPM models have no reliable creation timestamp, so `created` is
-        resolved via the probe -> proxy -> count chain (see
-        task-C6-context.md): probe `get_model_details` for a
-        creation-timestamp key -> earliest prediction datapoint with y>0
-        -> no CreationEvent (model still counted, just not on the
-        created-over-time chart). The wide predictions series is fetched
-        ONCE per model and reused for both the creation proxy and the
-        PREDICTION_VOLUME usage metric. This is ALL-TIME data; `self.window`
-        is not applied here. Degrades gracefully to `([], [])` if
-        `comet_mpm` is not installed, or if the model-inventory endpoint is
-        unavailable (e.g. MPM not provisioned for this account -> 404).
-        """
-        try:
-            import comet_mpm
-        except ImportError:
-            print("Warning: comet_mpm not installed; skipping MPM collection")
-            return [], []
-
-        events: list = []
-        usage: list = []
-
-        if self.limit is not None:
-            workspaces = list(workspaces)[: self.limit]
-
-        try:
-            mpm = comet_mpm.API(api_key=self.api.config["comet.api_key"])
-            resp = mpm._client.get("api/mpm/v3/workspaces")
-            all_workspaces = (resp or {}).get("workspaces", []) or []
-        except Exception as exc:
-            print(f"Warning: failed to list MPM workspaces: {_short_api_error(exc)}")
-            return [], []
-
-        interval_type = "HOURLY" if self.units == "hour" else "DAILY"
-        start_date = "2015-01-01T00:00:00Z"
-        end_date = datetime.datetime.now(datetime.timezone.utc).strftime(
-            "%Y-%m-%dT%H:%M:%SZ"
-        )
-
-        requested = set(workspaces)
-        selected_entries = [
-            ws_entry
-            for ws_entry in all_workspaces
-            # The MPM inventory shape is not verifiable live; guard against
-            # malformed elements so one bad entry can't crash the report.
-            if isinstance(ws_entry, dict) and ws_entry.get("workspaceName") in requested
-        ]
-        for ws_entry in tqdm(selected_entries, desc="MPM workspaces", unit="ws"):
-            ws = ws_entry.get("workspaceName")
-
-            models = ws_entry.get("models", []) or []
-            ws_counts: dict = defaultdict(float)
-            ws_total = 0.0
-
-            for model in tqdm(models, desc=f"MPM {ws}", unit="model", leave=False):
-                if not isinstance(model, dict):
-                    continue
-                model_name = model.get("modelName")
-                model_id = model.get("modelId")
-                try:
-                    points = self._mpm_prediction_points(
-                        mpm,
-                        model_id,
-                        start_date,
-                        end_date,
-                        interval_type,
-                    )
-                    created = self._mpm_model_created(mpm, model_id, points)
-                    if created is not None:
-                        events.append(
-                            CreationEvent(
-                                platform="mpm",
-                                workspace=ws,
-                                use_case=model_name,
-                                kind="mpm_model",
-                                created=created,
-                            )
-                        )
-
-                    counts = self._mpm_prediction_counts(points)
-                    total = sum(counts.values())
-                    usage.append(
-                        UsageMetric(
-                            platform="mpm",
-                            workspace=ws,
-                            metric="PREDICTION_VOLUME",
-                            value=total,
-                            project=model_name,
-                            series=(
-                                continuous_series(counts, self.units) if counts else []
-                            ),
-                        )
-                    )
-                    ws_total += total
-                    for key, n in counts.items():
-                        ws_counts[key] += n
-                except Exception as exc:
-                    print(
-                        f"Warning: failed to collect MPM model "
-                        f"{ws}/{model_name}: {exc}"
-                    )
-                    continue
-
-            usage.append(
-                self._workspace_usage_metric(
-                    "mpm", "PREDICTION_VOLUME", ws, ws_total, ws_counts
-                )
-            )
-
-        return events, usage
-
-    def _mpm_prediction_points(self, mpm, model_id, start_date, end_date, interval):
-        """Fetch the wide prediction series ONCE and return the raw
-        `[{"x": ..., "y": ...}, ...]` points, parsed defensively.
-
-        Reused by both `_mpm_model_created` (creation proxy) and
-        `_mpm_prediction_counts` (usage metric) -- never call
-        `get_nb_predictions` twice for the same model.
-        """
-        resp = mpm._client.get_nb_predictions(
-            model_id, start_date, end_date, interval, [], None
-        )
-        if not isinstance(resp, dict):
-            return []
-        series = resp.get("data") or []
-        if not series or not isinstance(series[0], dict):
-            return []
-        return series[0].get("data") or []
-
-    def _mpm_point_time(self, x):
-        """Parse a datapoint's `x` value (epoch-ms int/float or ISO str)."""
-        if isinstance(x, (int, float)):
-            return _ms_to_utc(x)
-        return datetime.datetime.fromisoformat(str(x).replace("Z", "+00:00"))
-
-    def _mpm_model_created(self, mpm, model_id, points):
-        """Resolve a model's `created` via probe -> proxy -> None chain."""
-        try:
-            details = mpm._client.get_model_details(model_id) or {}
-        except Exception:
-            details = {}
-
-        for key in (
-            "createdAt",
-            "creationDate",
-            "creationTimestamp",
-            "created_at",
-            "createdAtMillis",
-        ):
-            val = details.get(key)
-            if not val:
-                continue
-            if isinstance(val, (int, float)):
-                return _ms_to_utc(val)
-            try:
-                return datetime.datetime.fromisoformat(str(val).replace("Z", "+00:00"))
-            except ValueError:
-                continue
-
-        earliest = None
-        for point in points:
-            try:
-                x, y = point.get("x"), point.get("y")
-                if not y:
-                    continue
-                t = self._mpm_point_time(x)
-            except Exception:
-                continue
-            if earliest is None or t < earliest:
-                earliest = t
-        return earliest
-
-    def _mpm_prediction_counts(self, points):
-        """Bucket the pre-fetched prediction points by `self.units`."""
-        counts: dict = defaultdict(float)
-        for point in points:
-            try:
-                x, y = point.get("x"), point.get("y")
-                t = self._mpm_point_time(x)
-            except Exception:
-                continue
-            counts[format_time_key(t, self.units)] += _as_float(y)
-        return dict(counts)
-
-    def _em_experiment_counts(self, experiments):
-        """Bucket the project's pre-fetched experiment start timestamps by
-        `self.units` to build the all-time EXPERIMENT_COUNT over-time series."""
-        counts: dict = defaultdict(int)
-        for exp in experiments:
-            ms = getattr(exp, "start_server_timestamp", None)
-            if ms:
-                counts[format_time_key(_ms_to_utc(ms), self.units)] += 1
-        return dict(counts)
 
 
 def write_growth_html(report_data, output):

--- a/cometx/cli/admin_growth_report.py
+++ b/cometx/cli/admin_growth_report.py
@@ -89,6 +89,25 @@ def _num(value):
     return value
 
 
+def _window_growth(created_ms, window):
+    """Growth over the analysis window from a collection of creation timestamps
+    (epoch ms): `new_in` = items created within `[window.start, window.end]`,
+    `before` = items created before `window.start`, `pct` = new_in/before*100
+    (0-guarded). Shared by the workspace- and user-growth KPIs so the window
+    math lives in one place. `None` timestamps are skipped."""
+    new_in = before = 0
+    for c in created_ms:
+        if c is None:
+            continue
+        dt = _ms_to_utc(c)
+        if window.start <= dt <= window.end:
+            new_in += 1
+        elif dt < window.start:
+            before += 1
+    pct = round(new_in / before * 100, 1) if before else 0.0
+    return {"new_in": new_in, "before": before, "pct": pct}
+
+
 def _extract_service_account_names(payload) -> "set[str] | None":
     """Defensively unwrap the `/admin/service-accounts` response into a
     flat set of account names, tolerating several plausible response
@@ -431,14 +450,7 @@ class GrowthReporter:
                 cur = ws_created.get(ws)
                 if cur is None or u.created_at < cur:
                     ws_created[ws] = u.created_at
-        new_in = sum(
-            1
-            for c in ws_created.values()
-            if window.start <= _ms_to_utc(c) <= window.end
-        )
-        before = sum(1 for c in ws_created.values() if _ms_to_utc(c) < window.start)
-        pct = round(new_in / before * 100, 1) if before else 0.0
-        return {"new_in": new_in, "before": before, "pct": pct}
+        return _window_growth(ws_created.values(), window)
 
     def _build_unified_section(
         self,
@@ -630,25 +642,14 @@ class GrowthReporter:
         ]
 
         # User growth over the analysis window: new accounts in window /
-        # accounts before window (mirrors the workspace/project growth KPI).
+        # accounts before window (shares _window_growth with the workspace KPI).
         if window is not None:
-            new_in = sum(
-                1
-                for u in users
-                if u.created_at is not None
-                and window.start <= _ms_to_utc(u.created_at) <= window.end
-            )
-            before = sum(
-                1
-                for u in users
-                if u.created_at is not None and _ms_to_utc(u.created_at) < window.start
-            )
-            pct = round(new_in / before * 100, 1) if before else 0.0
+            growth = _window_growth((u.created_at for u in users), window)
             kpis.append(
                 {
                     "label": f"New in {self.window or '7d'} (% of base)",
-                    "value": f"{pct}%",
-                    "sub": f"+{new_in} new",
+                    "value": f"{growth['pct']}%",
+                    "sub": f"+{growth['new_in']} new",
                 }
             )
 

--- a/cometx/cli/admin_growth_report.py
+++ b/cometx/cli/admin_growth_report.py
@@ -1020,6 +1020,7 @@ class GrowthReporter:
                 continue
 
             ws_counts: dict = defaultdict(float)
+            ws_trace_counts: dict = defaultdict(float)
 
             for project in tqdm(projects, desc=f"Opik {ws}", unit="proj", leave=False):
                 try:
@@ -1067,6 +1068,43 @@ class GrowthReporter:
                     )
                     for key, val in counts.items():
                         ws_counts[key] += val
+
+                    try:
+                        trace_resp = client.rest_client.projects.get_project_metrics(
+                            project.id,
+                            metric_type="TRACE_COUNT",
+                            interval=interval,
+                            interval_start=interval_start,
+                            interval_end=now,
+                        )
+                        trace_counts: dict = defaultdict(float)
+                        for result in trace_resp.results or []:
+                            for dp in result.data or []:
+                                trace_counts[
+                                    format_time_key(dp.time, self.units)
+                                ] += _as_float(dp.value)
+
+                        usage.append(
+                            UsageMetric(
+                                platform="opik",
+                                workspace=ws,
+                                metric="TRACE_COUNT",
+                                value=sum(trace_counts.values()),
+                                project=project.name,
+                                series=(
+                                    continuous_series(dict(trace_counts), self.units)
+                                    if trace_counts
+                                    else []
+                                ),
+                            )
+                        )
+                        for key, val in trace_counts.items():
+                            ws_trace_counts[key] += val
+                    except Exception as exc:
+                        print(
+                            f"Warning: failed to collect Opik TRACE_COUNT for "
+                            f"{ws}/{getattr(project, 'name', '?')}: {exc}"
+                        )
                 except Exception as exc:
                     print(
                         f"Warning: failed to collect Opik project "
@@ -1077,6 +1115,15 @@ class GrowthReporter:
             usage.append(
                 self._workspace_usage_metric(
                     "opik", "SPAN_COUNT", ws, sum(ws_counts.values()), ws_counts
+                )
+            )
+            usage.append(
+                self._workspace_usage_metric(
+                    "opik",
+                    "TRACE_COUNT",
+                    ws,
+                    sum(ws_trace_counts.values()),
+                    ws_trace_counts,
                 )
             )
 

--- a/cometx/cli/admin_growth_users.py
+++ b/cometx/cli/admin_growth_users.py
@@ -21,6 +21,9 @@ CLI wiring. Later tasks (fetch, render, CLI) import from this module.
 from __future__ import annotations
 
 import dataclasses
+import datetime
+
+from cometx.utils import format_time_key, get_next_time_key, parse_time_key
 
 
 @dataclasses.dataclass(frozen=True)
@@ -94,11 +97,20 @@ def parse_users(chargeback: dict) -> "list[UserRecord]":
     return records
 
 
+def _within_window(ts: "int | None", window_end_ms: int, window_ms: int) -> bool:
+    """True if timestamp `ts` falls within a rolling window of `window_ms`
+    size ending at `window_end_ms` (inclusive of both bounds). False if
+    `ts` is None (field absent for this user/capability)."""
+    if ts is None:
+        return False
+    return (window_end_ms - window_ms) <= ts <= window_end_ms
+
+
 def is_active(user: UserRecord, now_ms: int, active_window_days: int) -> bool:
     """True if `user.last_used_at` falls within the active window ending at
     `now_ms` (inclusive of both bounds)."""
     window_ms = active_window_days * 86400 * 1000
-    return (now_ms - window_ms) <= user.last_used_at <= now_ms
+    return _within_window(user.last_used_at, now_ms, window_ms)
 
 
 def adoption_stats(users, now_ms: int, active_window_days: int) -> dict:
@@ -137,3 +149,120 @@ def bottom_users(users, key: str, n: int) -> "list[UserRecord]":
     scored = [(u, v) for u, v in scored if v is not None and v > 0]
     scored.sort(key=lambda pair: pair[1])
     return [u for u, _ in scored[:n]]
+
+
+def _ms_to_dt(ms: int) -> "datetime.datetime":
+    """Epoch-ms -> tz-aware UTC datetime (matches the `_ms_to_utc` helper
+    in admin_growth_report.py; duplicated here to avoid a circular import,
+    since that module imports FROM this one)."""
+    return datetime.datetime.fromtimestamp(ms / 1000, tz=datetime.timezone.utc)
+
+
+def _dt_to_ms(dt: "datetime.datetime") -> int:
+    """Datetime -> epoch-ms. `parse_time_key` (from `cometx.utils`) returns
+    naive datetimes; treat those as UTC (consistent with `_ms_to_dt` above)
+    rather than the platform-local timezone that `.timestamp()` would
+    otherwise assume."""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=datetime.timezone.utc)
+    return int(dt.timestamp() * 1000)
+
+
+def _bucket_keys(earliest_ms: int, now_ms: int, units: str) -> "list[str]":
+    """Zero-filled, ordered bucket keys from the bucket containing
+    `earliest_ms` through the bucket containing `now_ms`, inclusive.
+
+    Note: `continuous_series` (mentioned in the task brief) actually lives
+    in `admin_growth_report.py`, not `cometx.utils` -- and that module
+    imports FROM this one, so importing it back here would be circular.
+    This is the same zero-fill approach (via `get_next_time_key`), built
+    locally from the primitives that do live in `cometx.utils`
+    (`format_time_key`, `get_next_time_key`, `parse_time_key`)."""
+    start_key = format_time_key(_ms_to_dt(earliest_ms), units)
+    end_key = format_time_key(_ms_to_dt(now_ms), units)
+    keys = [start_key]
+    key = start_key
+    guard = 0
+    while key != end_key and guard < 100_000:
+        key = get_next_time_key(key, units)
+        keys.append(key)
+        guard += 1
+    return keys
+
+
+def _iter_buckets(users: "list[UserRecord]", units: str, now_ms: int):
+    """Yield `(key, bucket_end_ms, existing)` for each zero-filled bucket
+    from the earliest `created_at` through `now_ms`. `existing` is the
+    list of non-suspended users that had already been created (and not
+    yet deleted) as of `bucket_end_ms`. `bucket_end_ms` is capped at
+    `now_ms` so the current/last bucket reflects "as of now" rather than
+    the theoretical end of an in-progress period."""
+    created_times = [u.created_at for u in users if u.created_at is not None]
+    if not created_times:
+        return
+    earliest_ms = min(created_times)
+    if earliest_ms > now_ms:
+        earliest_ms = now_ms
+
+    for key in _bucket_keys(earliest_ms, now_ms, units):
+        next_key = get_next_time_key(key, units)
+        next_start_ms = _dt_to_ms(parse_time_key(next_key, units))
+        bucket_end_ms = min(next_start_ms - 1, now_ms)
+        existing = [
+            u
+            for u in users
+            if not u.suspended
+            and u.created_at is not None
+            and u.created_at <= bucket_end_ms
+            and (u.deleted_at is None or u.deleted_at >= bucket_end_ms)
+        ]
+        yield key, bucket_end_ms, existing
+
+
+def active_series(
+    users: "list[UserRecord]", units: str, now_ms: int, active_window_days: int
+) -> "list[dict]":
+    """One point per time bucket from the earliest `created_at` to `now_ms`:
+    `total` = non-suspended users existing (created and not-yet-deleted) as
+    of that bucket's end; `active` = the subset of those whose
+    `last_used_at` falls within a rolling `active_window_days` window
+    ending at that bucket's end. Returns `[]` if there are no users with a
+    known `created_at` (degrade, never crash)."""
+    window_ms = active_window_days * 86400 * 1000
+    points = []
+    for key, bucket_end_ms, existing in _iter_buckets(users, units, now_ms):
+        total = len(existing)
+        active = sum(
+            1 for u in existing if _within_window(u.last_used_at, bucket_end_ms, window_ms)
+        )
+        points.append({"key": key, "values": {"total": total, "active": active}})
+    return points
+
+
+def capability_series(
+    users: "list[UserRecord]", units: str, now_ms: int, active_window_days: int
+) -> "list[dict] | None":
+    """Like `active_series`, but per-capability: `em` = users active on EM
+    (`em_last_used_at` within the rolling window as of bucket-end); `opik`
+    = same for `opik_last_used_at`. Returns `None` when NO user in `users`
+    has either capability timestamp set (nothing to chart)."""
+    if not any(
+        u.em_last_used_at is not None or u.opik_last_used_at is not None for u in users
+    ):
+        return None
+
+    window_ms = active_window_days * 86400 * 1000
+    points = []
+    for key, bucket_end_ms, existing in _iter_buckets(users, units, now_ms):
+        em_active = sum(
+            1
+            for u in existing
+            if _within_window(u.em_last_used_at, bucket_end_ms, window_ms)
+        )
+        opik_active = sum(
+            1
+            for u in existing
+            if _within_window(u.opik_last_used_at, bucket_end_ms, window_ms)
+        )
+        points.append({"key": key, "values": {"em": em_active, "opik": opik_active}})
+    return points

--- a/cometx/cli/admin_growth_users.py
+++ b/cometx/cli/admin_growth_users.py
@@ -359,9 +359,15 @@ def _iter_buckets(users: "list[UserRecord]", units: str, now_ms: int):
         (u for u in users if not u.suspended and u.created_at is not None),
         key=lambda u: u.created_at,
     )
-    if not dated:
+    # The bucket RANGE is spanned by every dated user, suspended included, so
+    # these series share an x-axis start with `churn_series` (which reads
+    # created_at/deleted_at directly and cannot skip suspended accounts).
+    # Suspended users are still excluded from `existing`, so the leading
+    # buckets read as zero rather than being dropped from the chart.
+    created_times = [u.created_at for u in users if u.created_at is not None]
+    if not created_times:
         return
-    earliest_ms = dated[0].created_at
+    earliest_ms = min(created_times)
     if earliest_ms > now_ms:
         earliest_ms = now_ms
 

--- a/cometx/cli/admin_growth_users.py
+++ b/cometx/cli/admin_growth_users.py
@@ -154,25 +154,35 @@ def _metric_value(user: UserRecord, key: str):
     """Return the raw metric value for `key`, or None if the metric is
     absent for this user (only possible for opik_span_count)."""
     if key == "em_score":
-        return user.experiment_count + user.data_logged_mb
+        return (user.experiment_count or 0) + (user.data_logged_mb or 0)
     if key == "opik_span_count":
         return user.opik_span_count
     raise ValueError("Unsupported key: {}".format(key))
 
 
+def _rankable_users(users):
+    """Users eligible for the activity leaderboards: exclude deleted and
+    suspended accounts, matching the exclusions the time-series builders and
+    `classify_accounts` apply, so the leaderboard doesn't list a
+    deleted/suspended account as a current top user (which would contradict the
+    active/total and capability charts in the same report)."""
+    return [u for u in users if u.deleted_at is None and not u.suspended]
+
+
 def top_users(users, key: str, n: int) -> "list[UserRecord]":
-    """Top `n` users by `key` (descending), skipping users for whom the
-    metric is absent (None)."""
-    scored = [(u, _metric_value(u, key)) for u in users]
+    """Top `n` users by `key` (descending), over non-deleted/non-suspended
+    users, skipping those for whom the metric is absent (None)."""
+    scored = [(u, _metric_value(u, key)) for u in _rankable_users(users)]
     scored = [(u, v) for u, v in scored if v is not None]
     scored.sort(key=lambda pair: pair[1], reverse=True)
     return [u for u, _ in scored[:n]]
 
 
 def bottom_users(users, key: str, n: int) -> "list[UserRecord]":
-    """Bottom `n` users by `key` (ascending), active-aware: only considers
-    users whose metric value is strictly positive."""
-    scored = [(u, _metric_value(u, key)) for u in users]
+    """Bottom `n` users by `key` (ascending), over non-deleted/non-suspended
+    users, active-aware: only considers users whose metric value is strictly
+    positive."""
+    scored = [(u, _metric_value(u, key)) for u in _rankable_users(users)]
     scored = [(u, v) for u, v in scored if v is not None and v > 0]
     scored.sort(key=lambda pair: pair[1])
     return [u for u, _ in scored[:n]]
@@ -396,35 +406,34 @@ def adoption_rate_series(
     that total active within the rolling `active_window_days` window ending at
     bucket-end -- `overall` from `last_used_at` (active on ANY platform), `em`
     from `em_last_used_at`, `opik` from `opik_last_used_at`. Rates are
-    0-guarded when a bucket has no users. Returns `[]` when no user has a
-    known `created_at` (degrade, never crash)."""
+    0-guarded when a bucket has no users.
+
+    `overall` is always present; `em`/`opik` are OMITTED entirely when no user
+    carries that capability timestamp (mirrors `capability_series`), so an
+    absent capability is not charted as a misleading flat 0%. Returns `[]` when
+    no user has a known `created_at` (degrade, never crash)."""
+    has_em = any(u.em_last_used_at is not None for u in users)
+    has_opik = any(u.opik_last_used_at is not None for u in users)
     window_ms = active_window_days * 86400 * 1000
     points = []
     for key, bucket_end_ms, existing in _iter_buckets(users, units, now_ms):
         total = len(existing)
-        if total:
-            overall = sum(
+
+        def rate(getter):
+            if not total:
+                return 0.0
+            hits = sum(
                 1
                 for u in existing
-                if _within_window(u.last_used_at, bucket_end_ms, window_ms)
+                if _within_window(getter(u), bucket_end_ms, window_ms)
             )
-            em = sum(
-                1
-                for u in existing
-                if _within_window(u.em_last_used_at, bucket_end_ms, window_ms)
-            )
-            opik = sum(
-                1
-                for u in existing
-                if _within_window(u.opik_last_used_at, bucket_end_ms, window_ms)
-            )
-            values = {
-                "overall": round(overall / total * 100, 1),
-                "em": round(em / total * 100, 1),
-                "opik": round(opik / total * 100, 1),
-            }
-        else:
-            values = {"overall": 0.0, "em": 0.0, "opik": 0.0}
+            return round(hits / total * 100, 1)
+
+        values = {"overall": rate(lambda u: u.last_used_at)}
+        if has_em:
+            values["em"] = rate(lambda u: u.em_last_used_at)
+        if has_opik:
+            values["opik"] = rate(lambda u: u.opik_last_used_at)
         points.append({"key": key, "values": values})
     return points
 

--- a/cometx/cli/admin_growth_users.py
+++ b/cometx/cli/admin_growth_users.py
@@ -504,8 +504,13 @@ def workspace_active_series(
     lists but whose members carry no `created_at` -- are seeded into every
     bucket. Those can't be placed on the timeline, so attributing them to all of
     history is the least-wrong choice and keeps the final bucket matching
-    `workspace_active_stats(..., all_workspaces=...)` and the KPI. Returns `None`
-    only when there is nothing to show (no membership AND no `all_workspaces`)."""
+    `workspace_active_stats(..., all_workspaces=...)` and the KPI.
+
+    When no user carries a `created_at` there is no timeline at all, so a single
+    "as of now" bucket is emitted rather than an empty list -- an empty list
+    would make the caller drop the chart while its KPI still showed numbers.
+    Returns `None` only when there is nothing to show (no membership AND no
+    `all_workspaces`)."""
     all_ws = set(all_workspaces) if all_workspaces else set()
     datable_ws = {ws for u in users for ws in u.workspaces}
     # Workspaces we can never place on the timeline: seed them into every bucket.
@@ -524,6 +529,29 @@ def workspace_active_series(
                     active_ws.add(ws)
         points.append(
             {"key": key, "values": {"total": len(total_ws), "active": len(active_ws)}}
+        )
+    if not points:
+        # No user carries a `created_at`, so `_iter_buckets` has no timeline to
+        # bucket and yields nothing -- but `workspace_active_stats` still
+        # reports a total/active from membership alone. Returning `[]` here made
+        # the caller's `if ws_active_pts:` gate drop the chart while its KPI
+        # showed real numbers. Emit a single "as of now" bucket computed the way
+        # the KPI is (membership + `is_active`, ignoring `created_at`) so the two
+        # agree instead of one silently vanishing.
+        total_ws, active_ws = set(seed_ws), set()
+        for u in users:
+            if u.suspended:
+                continue
+            member_active = is_active(u, now_ms, active_window_days)
+            for ws in u.workspaces:
+                total_ws.add(ws)
+                if member_active:
+                    active_ws.add(ws)
+        points.append(
+            {
+                "key": format_time_key(_ms_to_dt(now_ms), units),
+                "values": {"total": len(total_ws), "active": len(active_ws)},
+            }
         )
     return points
 

--- a/cometx/cli/admin_growth_users.py
+++ b/cometx/cli/admin_growth_users.py
@@ -430,21 +430,31 @@ def adoption_rate_series(
 
 
 def workspace_active_series(
-    users: "list[UserRecord]", units: str, now_ms: int, active_window_days: int
+    users: "list[UserRecord]",
+    units: str,
+    now_ms: int,
+    active_window_days: int,
+    all_workspaces=None,
 ) -> "list[dict] | None":
-    """Per-bucket total vs active WORKSPACES. A workspace is counted as
-    existing in a bucket when it has at least one non-suspended member that
-    exists as of bucket-end, and active when at least one such member was
-    active within the rolling `active_window_days` window ending at bucket-end
-    (the same activity rule used for active users). Membership comes from the
-    chargeback reverse-map (`UserRecord.workspaces`). Returns `None` when no
-    user carries any workspace membership."""
-    if not any(u.workspaces for u in users):
+    """Per-bucket total vs active WORKSPACES. A workspace is active in a bucket
+    when at least one non-suspended member existing as of bucket-end was active
+    within the rolling `active_window_days` window (the same activity rule used
+    for active users). Membership comes from the chargeback reverse-map
+    (`UserRecord.workspaces`).
+
+    When `all_workspaces` (the authoritative chargeback workspace-name set) is
+    given, every bucket's `total` is seeded from it so the chart's total matches
+    `workspace_active_stats(..., all_workspaces=...)` and the KPI -- including
+    workspaces with zero datable members, which never appear in the membership
+    reverse-map. Returns `None` only when there is nothing to show (no
+    membership AND no `all_workspaces`)."""
+    seed_ws = set(all_workspaces) if all_workspaces else set()
+    if not seed_ws and not any(u.workspaces for u in users):
         return None
     window_ms = active_window_days * 86400 * 1000
     points = []
     for key, bucket_end_ms, existing in _iter_buckets(users, units, now_ms):
-        total_ws, active_ws = set(), set()
+        total_ws, active_ws = set(seed_ws), set()
         for u in existing:
             is_active_user = _within_window(u.last_used_at, bucket_end_ms, window_ms)
             for ws in u.workspaces:
@@ -544,6 +554,38 @@ def workspace_churn_series(
     ]
 
 
+def _user_breakdown_series(
+    users, units, now_ms, active_window_days, last_used_getter, counters
+):
+    """Shared per-bucket user-breakdown builder for the EM/Opik capability
+    breakdowns. `active` counts existing users whose `last_used_getter(u)`
+    falls within the rolling `active_window_days` window as of bucket-end; each
+    `(name, predicate)` in `counters` adds a per-bucket count of existing users
+    matching that predicate (snapshot cumulative, so a user is counted from the
+    bucket they first exist). Returns `None` when no user shows any signal
+    (a non-null activity timestamp or any counter predicate true)."""
+
+    def has_signal(u):
+        return last_used_getter(u) is not None or any(pred(u) for _, pred in counters)
+
+    if not any(has_signal(u) for u in users):
+        return None
+    window_ms = active_window_days * 86400 * 1000
+    points = []
+    for key, bucket_end_ms, existing in _iter_buckets(users, units, now_ms):
+        values = {
+            "active": sum(
+                1
+                for u in existing
+                if _within_window(last_used_getter(u), bucket_end_ms, window_ms)
+            )
+        }
+        for name, pred in counters:
+            values[name] = sum(1 for u in existing if pred(u))
+        points.append({"key": key, "values": values})
+    return points
+
+
 def em_user_breakdown_series(
     users: "list[UserRecord]", units: str, now_ms: int, active_window_days: int
 ) -> "list[dict] | None":
@@ -553,35 +595,17 @@ def em_user_breakdown_series(
     cumulative totals, so a user is counted from the bucket they first exist
     (an approximation that matches the client notebook). Returns `None` when
     there is no EM signal at all."""
-    has_em = any(
-        u.em_last_used_at is not None
-        or (u.experiment_count or 0) > 0
-        or (u.data_logged_mb or 0) > 0
-        for u in users
+    return _user_breakdown_series(
+        users,
+        units,
+        now_ms,
+        active_window_days,
+        last_used_getter=lambda u: u.em_last_used_at,
+        counters=[
+            ("experimenters", lambda u: (u.experiment_count or 0) > 0),
+            ("data_pushers", lambda u: (u.data_logged_mb or 0) > 0),
+        ],
     )
-    if not has_em:
-        return None
-    window_ms = active_window_days * 86400 * 1000
-    points = []
-    for key, bucket_end_ms, existing in _iter_buckets(users, units, now_ms):
-        active = sum(
-            1
-            for u in existing
-            if _within_window(u.em_last_used_at, bucket_end_ms, window_ms)
-        )
-        experimenters = sum(1 for u in existing if (u.experiment_count or 0) > 0)
-        data_pushers = sum(1 for u in existing if (u.data_logged_mb or 0) > 0)
-        points.append(
-            {
-                "key": key,
-                "values": {
-                    "active": active,
-                    "experimenters": experimenters,
-                    "data_pushers": data_pushers,
-                },
-            }
-        )
-    return points
 
 
 def opik_user_breakdown_series(
@@ -590,27 +614,14 @@ def opik_user_breakdown_series(
     """Per-bucket Opik user breakdown: `active` (`opik_last_used_at` within the
     rolling window) and `span_producers` (`opik_span_count` > 0, snapshot
     cumulative). Returns `None` when there is no Opik signal at all."""
-    has_opik = any(
-        u.opik_last_used_at is not None or (u.opik_span_count or 0) > 0 for u in users
+    return _user_breakdown_series(
+        users,
+        units,
+        now_ms,
+        active_window_days,
+        last_used_getter=lambda u: u.opik_last_used_at,
+        counters=[("span_producers", lambda u: (u.opik_span_count or 0) > 0)],
     )
-    if not has_opik:
-        return None
-    window_ms = active_window_days * 86400 * 1000
-    points = []
-    for key, bucket_end_ms, existing in _iter_buckets(users, units, now_ms):
-        active = sum(
-            1
-            for u in existing
-            if _within_window(u.opik_last_used_at, bucket_end_ms, window_ms)
-        )
-        span_producers = sum(1 for u in existing if (u.opik_span_count or 0) > 0)
-        points.append(
-            {
-                "key": key,
-                "values": {"active": active, "span_producers": span_producers},
-            }
-        )
-    return points
 
 
 @dataclasses.dataclass(frozen=True)
@@ -621,7 +632,7 @@ class WorkspaceRecord:
     num_experiments: float
     data_mb: float
     num_projects: int
-    members: "list"  # member usernames
+    members: "tuple"  # member usernames (immutable, matching frozen=True)
 
 
 def parse_workspaces(chargeback: dict) -> "list[WorkspaceRecord]":
@@ -638,9 +649,9 @@ def parse_workspaces(chargeback: dict) -> "list[WorkspaceRecord]":
             num_projects = int(projects)
         else:
             num_projects = 0
-        members = [
+        members = tuple(
             m.get("userName") for m in (w.get("members") or []) if m.get("userName")
-        ]
+        )
         out.append(
             WorkspaceRecord(
                 name=w.get("name"),

--- a/cometx/cli/admin_growth_users.py
+++ b/cometx/cli/admin_growth_users.py
@@ -22,9 +22,12 @@ from __future__ import annotations
 
 import dataclasses
 import datetime
+import logging
 import re
 
 from cometx.utils import format_time_key, get_next_time_key, parse_time_key
+
+LOGGER = logging.getLogger(__name__)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -242,8 +245,12 @@ def classify_accounts(users, service_account_names=None) -> dict:
 
     `service_account_names`, when a set, is the authoritative list fetched
     from the admin `/admin/service-accounts` endpoint: membership in that
-    set (by `username`) decides the split, and `source` is reported as
-    "admin_api". When it is `None` (the endpoint failed, was disabled, or
+    set decides the split, and `source` is reported as "admin_api".
+    Because the endpoint may identify accounts by either username or
+    email, a user matches if *either* their `username` or their `email` is
+    in the set (avoids the mirror failure where entries carry only email
+    but users are matched on username, silently classifying everyone as
+    personal). When it is `None` (the endpoint failed, was disabled, or
     isn't present in this deployment), falls back to a labeled regex
     heuristic (`_looks_like_service_account`) and reports `source` as
     "heuristic" so callers can surface which method produced the split.
@@ -252,7 +259,10 @@ def classify_accounts(users, service_account_names=None) -> dict:
         source = "admin_api"
 
         def is_service(user: UserRecord) -> bool:
-            return user.username in service_account_names
+            return (
+                user.username in service_account_names
+                or user.email in service_account_names
+            )
 
     else:
         source = "heuristic"
@@ -310,10 +320,23 @@ def _bucket_keys(earliest_ms: int, now_ms: int, units: str) -> "list[str]":
     keys = [start_key]
     key = start_key
     guard = 0
-    while key != end_key and guard < 100_000:
+    guard_max = 100_000
+    while key != end_key and guard < guard_max:
         key = get_next_time_key(key, units)
         keys.append(key)
         guard += 1
+    if key != end_key:
+        # Span too large for these units (e.g. hourly buckets over years):
+        # the series is truncated at the guard, so warn rather than silently
+        # returning a chart that stops short of `now`.
+        LOGGER.warning(
+            "Growth series truncated at %d %s buckets (spanning %s..%s); "
+            "the chart stops before the current period. Use coarser units.",
+            guard_max,
+            units,
+            start_key,
+            end_key,
+        )
     return keys
 
 
@@ -451,14 +474,25 @@ def workspace_active_series(
     for active users). Membership comes from the chargeback reverse-map
     (`UserRecord.workspaces`).
 
+    The per-bucket `total` grows over time: a workspace counts from the bucket
+    in which its earliest member existed (using the same created/not-yet-deleted
+    membership as `_iter_buckets`). This keeps the total line honest about
+    history instead of flat, while still reaching the authoritative count in the
+    final bucket.
+
     When `all_workspaces` (the authoritative chargeback workspace-name set) is
-    given, every bucket's `total` is seeded from it so the chart's total matches
-    `workspace_active_stats(..., all_workspaces=...)` and the KPI -- including
-    workspaces with zero datable members, which never appear in the membership
-    reverse-map. Returns `None` only when there is nothing to show (no
-    membership AND no `all_workspaces`)."""
-    seed_ws = set(all_workspaces) if all_workspaces else set()
-    if not seed_ws and not any(u.workspaces for u in users):
+    given, only its *undatable* members -- workspaces that never appear in the
+    membership reverse-map, e.g. zero-member workspaces the chargeback snapshot
+    lists but whose members carry no `created_at` -- are seeded into every
+    bucket. Those can't be placed on the timeline, so attributing them to all of
+    history is the least-wrong choice and keeps the final bucket matching
+    `workspace_active_stats(..., all_workspaces=...)` and the KPI. Returns `None`
+    only when there is nothing to show (no membership AND no `all_workspaces`)."""
+    all_ws = set(all_workspaces) if all_workspaces else set()
+    datable_ws = {ws for u in users for ws in u.workspaces}
+    # Workspaces we can never place on the timeline: seed them into every bucket.
+    seed_ws = all_ws - datable_ws
+    if not all_ws and not datable_ws:
         return None
     window_ms = active_window_days * 86400 * 1000
     points = []

--- a/cometx/cli/admin_growth_users.py
+++ b/cometx/cli/admin_growth_users.py
@@ -164,8 +164,12 @@ _SERVICE_ACCOUNT_PREFIX_PATTERN = re.compile(
     r"(?:^|[._-])(?:svc|sa|bot)-", re.IGNORECASE
 )
 # Segment token: matched as-is against the username (already has a leading
-# hyphen boundary, so no separate anchoring is needed).
-_SERVICE_ACCOUNT_SEGMENT_PATTERN = re.compile(r"-service-account", re.IGNORECASE)
+# hyphen boundary, so no separate anchoring is needed). Bounded at the tail
+# to end-of-string or the next separator so "jane-service-accountant" is not
+# mislabeled as a service account.
+_SERVICE_ACCOUNT_SEGMENT_PATTERN = re.compile(
+    r"-service-account(?:$|[._-])", re.IGNORECASE
+)
 # Domain token: matched against the email's domain only, anchored to the
 # END of the domain, so "sagemaker-integration.com" matches but a lookalike
 # domain like "sagemaker-integration.com.evil.com" does not.

--- a/cometx/cli/admin_growth_users.py
+++ b/cometx/cli/admin_growth_users.py
@@ -154,26 +154,39 @@ def bottom_users(users, key: str, n: int) -> "list[UserRecord]":
 
 # Labeled regex fallback used by `classify_accounts` when the admin
 # `/admin/service-accounts` endpoint is unavailable (disabled, 403/404, or
-# any other fetch failure). Matched case-insensitively against username OR
-# email, since either field may carry the naming convention.
-_SERVICE_ACCOUNT_PATTERNS = [
-    re.compile(pattern, re.IGNORECASE)
-    for pattern in (
-        r"svc-",
-        r"sa-",
-        r"-service-account",
-        r"bot-",
-        r"sagemaker-integration\.com",
-    )
-]
+# any other fetch failure). Anchored to name-segment/domain boundaries so a
+# real user like "lisa-brown" or "abbot-jones" (which merely CONTAIN "sa-"
+# / "bot-" mid-string) is never mislabeled as a service account.
+
+# Prefix-style tokens: match only at the start of the username, or right
+# after a `.`/`_`/`-` separator (i.e. as a whole name-segment prefix).
+_SERVICE_ACCOUNT_PREFIX_PATTERN = re.compile(
+    r"(?:^|[._-])(?:svc|sa|bot)-", re.IGNORECASE
+)
+# Segment token: matched as-is against the username (already has a leading
+# hyphen boundary, so no separate anchoring is needed).
+_SERVICE_ACCOUNT_SEGMENT_PATTERN = re.compile(r"-service-account", re.IGNORECASE)
+# Domain token: matched against the email's domain only, anchored to the
+# END of the domain, so "sagemaker-integration.com" matches but a lookalike
+# domain like "sagemaker-integration.com.evil.com" does not.
+_SERVICE_ACCOUNT_DOMAIN_PATTERN = re.compile(
+    r"(?:^|\.)sagemaker-integration\.com$", re.IGNORECASE
+)
 
 
 def _looks_like_service_account(user: UserRecord) -> bool:
     """Heuristic-only check (used when no authoritative service-account set
-    is available): does the username or email match one of the known
-    service-account naming conventions."""
-    haystack = "{} {}".format(user.username or "", user.email or "")
-    return any(pattern.search(haystack) for pattern in _SERVICE_ACCOUNT_PATTERNS)
+    is available): does the username match one of the known service-account
+    naming conventions, or does the email's domain match a known
+    service-account domain."""
+    username = user.username or ""
+    if _SERVICE_ACCOUNT_PREFIX_PATTERN.search(username):
+        return True
+    if _SERVICE_ACCOUNT_SEGMENT_PATTERN.search(username):
+        return True
+    email = user.email or ""
+    domain = email.rsplit("@", 1)[-1] if "@" in email else ""
+    return bool(domain and _SERVICE_ACCOUNT_DOMAIN_PATTERN.search(domain))
 
 
 def classify_accounts(users, service_account_names=None) -> dict:

--- a/cometx/cli/admin_growth_users.py
+++ b/cometx/cli/admin_growth_users.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# ****************************************
+#                              __
+#   _________  ____ ___  ___  / /__  __
+#  / ___/ __ \/ __ `__ \/ _ \/ __/ |/_/
+# / /__/ /_/ / / / / / /  __/ /__>  <
+# \___/\____/_/ /_/ /_/\___/\__/_/|_|
+#
+#
+#  Copyright (c) 2024 Cometx Development
+#      Team. All rights reserved.
+# ****************************************
+"""People/usage layer for `cometx admin growth-report`, derived from the
+chargeback report.
+
+Pure parse + derivation functions only: no HTTP calls, no rendering, no
+CLI wiring. Later tasks (fetch, render, CLI) import from this module.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+
+@dataclasses.dataclass(frozen=True)
+class UserRecord:
+    """A single licensed user, as reported by the chargeback report, with
+    workspace membership reverse-mapped in."""
+
+    username: str
+    email: str
+    created_at: int
+    deleted_at: "int | None"
+    suspended: bool
+    last_used_at: int
+    experiment_count: float
+    data_logged_mb: float
+    opik_span_count: "float | None" = None
+    em_last_used_at: "int | None" = None
+    opik_last_used_at: "int | None" = None
+    workspaces: "list" = dataclasses.field(default_factory=list)
+
+
+def _extract_licensed_users(users_field) -> list:
+    """Defensively unwrap the `chargeback["users"]` container, which may be:
+    a dict with a `report` key, a dict with a `licensedUsers` key, or a bare
+    list of user records."""
+    if isinstance(users_field, dict):
+        if "licensedUsers" in users_field:
+            return users_field.get("licensedUsers") or []
+        if "report" in users_field:
+            report = users_field.get("report")
+            return _extract_licensed_users(report) if report is not None else []
+        return []
+    if isinstance(users_field, list):
+        return users_field
+    return []
+
+
+def parse_users(chargeback: dict) -> "list[UserRecord]":
+    """Parse `chargeback["users"]` into `UserRecord`s, reverse-mapping
+    `workspaces[].members[].userName` into each user's `workspaces` list."""
+    raw_users = _extract_licensed_users((chargeback or {}).get("users"))
+
+    workspaces_by_username: "dict[str, list[str]]" = {}
+    for ws in (chargeback or {}).get("workspaces") or []:
+        ws_name = ws.get("name")
+        for member in ws.get("members") or []:
+            user_name = member.get("userName")
+            if user_name is None:
+                continue
+            workspaces_by_username.setdefault(user_name, []).append(ws_name)
+
+    records = []
+    for raw in raw_users:
+        username = raw.get("username")
+        records.append(
+            UserRecord(
+                username=username,
+                email=raw.get("email"),
+                created_at=raw.get("createdAt"),
+                deleted_at=raw.get("deletedAt"),
+                suspended=raw.get("suspended", False),
+                last_used_at=raw.get("lastUsedAt"),
+                experiment_count=raw.get("experimentCount", 0),
+                data_logged_mb=raw.get("dataLoggedMb", 0.0),
+                opik_span_count=raw.get("opikSpanCount"),
+                em_last_used_at=raw.get("emLastUsedAt"),
+                opik_last_used_at=raw.get("opikLastUsedAt"),
+                workspaces=list(workspaces_by_username.get(username, [])),
+            )
+        )
+    return records
+
+
+def is_active(user: UserRecord, now_ms: int, active_window_days: int) -> bool:
+    """True if `user.last_used_at` falls within the active window ending at
+    `now_ms` (inclusive of both bounds)."""
+    window_ms = active_window_days * 86400 * 1000
+    return (now_ms - window_ms) <= user.last_used_at <= now_ms
+
+
+def adoption_stats(users, now_ms: int, active_window_days: int) -> dict:
+    """Aggregate adoption stats. `total` excludes suspended users;
+    `adoption_pct` is 0-guarded when there are no non-suspended users."""
+    non_suspended = [u for u in users if not u.suspended]
+    total = len(non_suspended)
+    active = sum(1 for u in non_suspended if is_active(u, now_ms, active_window_days))
+    adoption_pct = round(active / total * 100, 1) if total else 0.0
+    return {"total": total, "active": active, "adoption_pct": adoption_pct}
+
+
+def _metric_value(user: UserRecord, key: str):
+    """Return the raw metric value for `key`, or None if the metric is
+    absent for this user (only possible for opik_span_count)."""
+    if key == "em_score":
+        return user.experiment_count + user.data_logged_mb
+    if key == "opik_span_count":
+        return user.opik_span_count
+    raise ValueError("Unsupported key: {}".format(key))
+
+
+def top_users(users, key: str, n: int) -> "list[UserRecord]":
+    """Top `n` users by `key` (descending), skipping users for whom the
+    metric is absent (None)."""
+    scored = [(u, _metric_value(u, key)) for u in users]
+    scored = [(u, v) for u, v in scored if v is not None]
+    scored.sort(key=lambda pair: pair[1], reverse=True)
+    return [u for u, _ in scored[:n]]
+
+
+def bottom_users(users, key: str, n: int) -> "list[UserRecord]":
+    """Bottom `n` users by `key` (ascending), active-aware: only considers
+    users whose metric value is strictly positive."""
+    scored = [(u, _metric_value(u, key)) for u in users]
+    scored = [(u, v) for u, v in scored if v is not None and v > 0]
+    scored.sort(key=lambda pair: pair[1])
+    return [u for u, _ in scored[:n]]

--- a/cometx/cli/admin_growth_users.py
+++ b/cometx/cli/admin_growth_users.py
@@ -226,7 +226,11 @@ def classify_accounts(users, service_account_names=None) -> dict:
         bucket["data"] += user.data_logged_mb or 0
         bucket["spans"] += user.opik_span_count or 0
 
-    return {"personal": totals["personal"], "service": totals["service"], "source": source}
+    return {
+        "personal": totals["personal"],
+        "service": totals["service"],
+        "source": source,
+    }
 
 
 def _ms_to_dt(ms: int) -> "datetime.datetime":
@@ -311,7 +315,9 @@ def active_series(
     for key, bucket_end_ms, existing in _iter_buckets(users, units, now_ms):
         total = len(existing)
         active = sum(
-            1 for u in existing if _within_window(u.last_used_at, bucket_end_ms, window_ms)
+            1
+            for u in existing
+            if _within_window(u.last_used_at, bucket_end_ms, window_ms)
         )
         points.append({"key": key, "values": {"total": total, "active": active}})
     return points

--- a/cometx/cli/admin_growth_users.py
+++ b/cometx/cli/admin_growth_users.py
@@ -535,22 +535,19 @@ def workspace_active_series(
         # bucket and yields nothing -- but `workspace_active_stats` still
         # reports a total/active from membership alone. Returning `[]` here made
         # the caller's `if ws_active_pts:` gate drop the chart while its KPI
-        # showed real numbers. Emit a single "as of now" bucket computed the way
-        # the KPI is (membership + `is_active`, ignoring `created_at`) so the two
-        # agree instead of one silently vanishing.
-        total_ws, active_ws = set(seed_ws), set()
-        for u in users:
-            if u.suspended:
-                continue
-            member_active = is_active(u, now_ms, active_window_days)
-            for ws in u.workspaces:
-                total_ws.add(ws)
-                if member_active:
-                    active_ws.add(ws)
+        # showed real numbers. Emit a single "as of now" bucket whose numbers are
+        # `workspace_active_stats`' by construction, so the chart and its KPI
+        # cannot disagree: `total` is the authoritative `all_workspaces` count
+        # when given (NOT the seeded/membership subset -- a workspace whose only
+        # members are suspended is absent from both, yet still counts toward the
+        # KPI denominator), falling back to membership when it isn't.
+        stats = workspace_active_stats(
+            users, now_ms, active_window_days, all_workspaces=all_workspaces
+        )
         points.append(
             {
                 "key": format_time_key(_ms_to_dt(now_ms), units),
-                "values": {"total": len(total_ws), "active": len(active_ws)},
+                "values": {"total": stats["total"], "active": stats["active"]},
             }
         )
     return points

--- a/cometx/cli/admin_growth_users.py
+++ b/cometx/cli/admin_growth_users.py
@@ -347,24 +347,36 @@ def _iter_buckets(users: "list[UserRecord]", units: str, now_ms: int):
     yet deleted) as of `bucket_end_ms`. `bucket_end_ms` is capped at
     `now_ms` so the current/last bucket reflects "as of now" rather than
     the theoretical end of an in-progress period."""
-    created_times = [u.created_at for u in users if u.created_at is not None]
-    if not created_times:
+    # Sort the eligible (non-suspended, dated) users by `created_at` once so
+    # each bucket can *admit* newly-created users via a sweep pointer instead
+    # of rescanning the whole list. This turns the created-side filter from
+    # O(buckets x users) into a single pass; the only per-bucket work left is
+    # dropping users whose deletion has passed (cheap unless there are many
+    # deletions). Buckets are yielded in increasing time order, and
+    # `created_at` only ever admits (never removes) as time advances, so the
+    # sweep is safe.
+    dated = sorted(
+        (u for u in users if not u.suspended and u.created_at is not None),
+        key=lambda u: u.created_at,
+    )
+    if not dated:
         return
-    earliest_ms = min(created_times)
+    earliest_ms = dated[0].created_at
     if earliest_ms > now_ms:
         earliest_ms = now_ms
 
+    admitted: "list[UserRecord]" = []
+    ptr = 0
+    n = len(dated)
     for key in _bucket_keys(earliest_ms, now_ms, units):
         next_key = get_next_time_key(key, units)
         next_start_ms = _dt_to_ms(parse_time_key(next_key, units))
         bucket_end_ms = min(next_start_ms - 1, now_ms)
+        while ptr < n and dated[ptr].created_at <= bucket_end_ms:
+            admitted.append(dated[ptr])
+            ptr += 1
         existing = [
-            u
-            for u in users
-            if not u.suspended
-            and u.created_at is not None
-            and u.created_at <= bucket_end_ms
-            and (u.deleted_at is None or u.deleted_at >= bucket_end_ms)
+            u for u in admitted if u.deleted_at is None or u.deleted_at >= bucket_end_ms
         ]
         yield key, bucket_end_ms, existing
 
@@ -520,7 +532,7 @@ def churn_series(
     the chargeback snapshot are visible, so hard-deleted accounts are not
     counted -- `deleted` reflects soft-deletes only. Returns `None` when no
     user has a known `created_at`."""
-    created = [u.created_at for u in users if u.created_at]
+    created = [u.created_at for u in users if u.created_at is not None]
     if not created:
         return None
     earliest_ms = min(created)
@@ -530,10 +542,10 @@ def churn_series(
     added_counts: dict = {}
     deleted_counts: dict = {}
     for u in users:
-        if u.created_at:
+        if u.created_at is not None:
             k = format_time_key(_ms_to_dt(u.created_at), units)
             added_counts[k] = added_counts.get(k, 0) + 1
-        if u.deleted_at:
+        if u.deleted_at is not None:
             k = format_time_key(_ms_to_dt(u.deleted_at), units)
             deleted_counts[k] = deleted_counts.get(k, 0) + 1
 

--- a/cometx/cli/admin_growth_users.py
+++ b/cometx/cli/admin_growth_users.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import dataclasses
 import datetime
+import re
 
 from cometx.utils import format_time_key, get_next_time_key, parse_time_key
 
@@ -149,6 +150,70 @@ def bottom_users(users, key: str, n: int) -> "list[UserRecord]":
     scored = [(u, v) for u, v in scored if v is not None and v > 0]
     scored.sort(key=lambda pair: pair[1])
     return [u for u, _ in scored[:n]]
+
+
+# Labeled regex fallback used by `classify_accounts` when the admin
+# `/admin/service-accounts` endpoint is unavailable (disabled, 403/404, or
+# any other fetch failure). Matched case-insensitively against username OR
+# email, since either field may carry the naming convention.
+_SERVICE_ACCOUNT_PATTERNS = [
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"svc-",
+        r"sa-",
+        r"-service-account",
+        r"bot-",
+        r"sagemaker-integration\.com",
+    )
+]
+
+
+def _looks_like_service_account(user: UserRecord) -> bool:
+    """Heuristic-only check (used when no authoritative service-account set
+    is available): does the username or email match one of the known
+    service-account naming conventions."""
+    haystack = "{} {}".format(user.username or "", user.email or "")
+    return any(pattern.search(haystack) for pattern in _SERVICE_ACCOUNT_PATTERNS)
+
+
+def classify_accounts(users, service_account_names=None) -> dict:
+    """Split all NON-DELETED users into "personal" vs "service" buckets and
+    sum experiments / data / spans across each bucket (suspended users are
+    still non-deleted, so they are included in whichever bucket they land
+    in; their own metrics are typically 0 either way).
+
+    `service_account_names`, when a set, is the authoritative list fetched
+    from the admin `/admin/service-accounts` endpoint: membership in that
+    set (by `username`) decides the split, and `source` is reported as
+    "admin_api". When it is `None` (the endpoint failed, was disabled, or
+    isn't present in this deployment), falls back to a labeled regex
+    heuristic (`_looks_like_service_account`) and reports `source` as
+    "heuristic" so callers can surface which method produced the split.
+    """
+    if service_account_names is not None:
+        source = "admin_api"
+
+        def is_service(user: UserRecord) -> bool:
+            return user.username in service_account_names
+
+    else:
+        source = "heuristic"
+        is_service = _looks_like_service_account
+
+    totals = {
+        "personal": {"experiments": 0, "data": 0, "spans": 0},
+        "service": {"experiments": 0, "data": 0, "spans": 0},
+    }
+
+    for user in users:
+        if user.deleted_at is not None:
+            continue
+        bucket = totals["service"] if is_service(user) else totals["personal"]
+        bucket["experiments"] += user.experiment_count or 0
+        bucket["data"] += user.data_logged_mb or 0
+        bucket["spans"] += user.opik_span_count or 0
+
+    return {"personal": totals["personal"], "service": totals["service"], "source": source}
 
 
 def _ms_to_dt(ms: int) -> "datetime.datetime":

--- a/cometx/cli/admin_growth_users.py
+++ b/cometx/cli/admin_growth_users.py
@@ -124,6 +124,32 @@ def adoption_stats(users, now_ms: int, active_window_days: int) -> dict:
     return {"total": total, "active": active, "adoption_pct": adoption_pct}
 
 
+def workspace_active_stats(
+    users, now_ms: int, active_window_days: int, all_workspaces=None
+) -> dict:
+    """Workspace-level analogue of `adoption_stats`. A workspace is `active`
+    when it has a non-suspended member active within the window (same rule as
+    active users). `total` is the size of `all_workspaces` when provided (the
+    authoritative chargeback workspace list, so the denominator matches the
+    "Total workspaces" count even for zero-member/inactive workspaces);
+    otherwise it falls back to the set of workspaces seen via membership.
+    `active_pct` is 0-guarded."""
+    active_ws = set()
+    member_ws = set()
+    for u in users:
+        if u.suspended:
+            continue
+        member_active = is_active(u, now_ms, active_window_days)
+        for ws in u.workspaces:
+            member_ws.add(ws)
+            if member_active:
+                active_ws.add(ws)
+    total = len(all_workspaces) if all_workspaces is not None else len(member_ws)
+    active = len(active_ws)
+    active_pct = round(active / total * 100, 1) if total else 0.0
+    return {"total": total, "active": active, "active_pct": active_pct}
+
+
 def _metric_value(user: UserRecord, key: str):
     """Return the raw metric value for `key`, or None if the metric is
     absent for this user (only possible for opik_span_count)."""
@@ -161,8 +187,11 @@ def bottom_users(users, key: str, n: int) -> "list[UserRecord]":
 # Prefix-style tokens: match only at the start of the username, or right
 # after a `.`/`_`/`-` separator (i.e. as a whole name-segment prefix).
 _SERVICE_ACCOUNT_PREFIX_PATTERN = re.compile(
-    r"(?:^|[._-])(?:svc|sa|bot)-", re.IGNORECASE
+    r"(?:^|[._-])(?:svc|sa|bot|pipeline)-", re.IGNORECASE
 )
+# Keyword token: the client notebook flags any username containing "automated"
+# as a service account (substring match). Kept as a plain substring for parity.
+_SERVICE_ACCOUNT_KEYWORD_PATTERN = re.compile(r"automated", re.IGNORECASE)
 # Segment token: matched as-is against the username (already has a leading
 # hyphen boundary, so no separate anchoring is needed). Bounded at the tail
 # to end-of-string or the next separator so "jane-service-accountant" is not
@@ -187,6 +216,8 @@ def _looks_like_service_account(user: UserRecord) -> bool:
     if _SERVICE_ACCOUNT_PREFIX_PATTERN.search(username):
         return True
     if _SERVICE_ACCOUNT_SEGMENT_PATTERN.search(username):
+        return True
+    if _SERVICE_ACCOUNT_KEYWORD_PATTERN.search(username):
         return True
     email = user.email or ""
     domain = email.rsplit("@", 1)[-1] if "@" in email else ""
@@ -354,3 +385,309 @@ def capability_series(
         )
         points.append({"key": key, "values": {"em": em_active, "opik": opik_active}})
     return points
+
+
+def adoption_rate_series(
+    users: "list[UserRecord]", units: str, now_ms: int, active_window_days: int
+) -> "list[dict]":
+    """Per-bucket adoption RATES (percentages), mirroring the client
+    notebook's "Adoption Rates" panel. For each bucket: `total` =
+    non-suspended users existing as of bucket-end; each rate is the share of
+    that total active within the rolling `active_window_days` window ending at
+    bucket-end -- `overall` from `last_used_at` (active on ANY platform), `em`
+    from `em_last_used_at`, `opik` from `opik_last_used_at`. Rates are
+    0-guarded when a bucket has no users. Returns `[]` when no user has a
+    known `created_at` (degrade, never crash)."""
+    window_ms = active_window_days * 86400 * 1000
+    points = []
+    for key, bucket_end_ms, existing in _iter_buckets(users, units, now_ms):
+        total = len(existing)
+        if total:
+            overall = sum(
+                1
+                for u in existing
+                if _within_window(u.last_used_at, bucket_end_ms, window_ms)
+            )
+            em = sum(
+                1
+                for u in existing
+                if _within_window(u.em_last_used_at, bucket_end_ms, window_ms)
+            )
+            opik = sum(
+                1
+                for u in existing
+                if _within_window(u.opik_last_used_at, bucket_end_ms, window_ms)
+            )
+            values = {
+                "overall": round(overall / total * 100, 1),
+                "em": round(em / total * 100, 1),
+                "opik": round(opik / total * 100, 1),
+            }
+        else:
+            values = {"overall": 0.0, "em": 0.0, "opik": 0.0}
+        points.append({"key": key, "values": values})
+    return points
+
+
+def workspace_active_series(
+    users: "list[UserRecord]", units: str, now_ms: int, active_window_days: int
+) -> "list[dict] | None":
+    """Per-bucket total vs active WORKSPACES. A workspace is counted as
+    existing in a bucket when it has at least one non-suspended member that
+    exists as of bucket-end, and active when at least one such member was
+    active within the rolling `active_window_days` window ending at bucket-end
+    (the same activity rule used for active users). Membership comes from the
+    chargeback reverse-map (`UserRecord.workspaces`). Returns `None` when no
+    user carries any workspace membership."""
+    if not any(u.workspaces for u in users):
+        return None
+    window_ms = active_window_days * 86400 * 1000
+    points = []
+    for key, bucket_end_ms, existing in _iter_buckets(users, units, now_ms):
+        total_ws, active_ws = set(), set()
+        for u in existing:
+            is_active_user = _within_window(u.last_used_at, bucket_end_ms, window_ms)
+            for ws in u.workspaces:
+                total_ws.add(ws)
+                if is_active_user:
+                    active_ws.add(ws)
+        points.append(
+            {"key": key, "values": {"total": len(total_ws), "active": len(active_ws)}}
+        )
+    return points
+
+
+def churn_series(
+    users: "list[UserRecord]", units: str, now_ms: int
+) -> "list[dict] | None":
+    """Per-bucket user churn: `added` = accounts created in the bucket,
+    `deleted` = accounts whose deletion date falls in the bucket. Both are
+    read straight from `created_at`/`deleted_at` (no snapshot set-diffing, so
+    no reconstructed-membership bug). Caveat: only accounts still present in
+    the chargeback snapshot are visible, so hard-deleted accounts are not
+    counted -- `deleted` reflects soft-deletes only. Returns `None` when no
+    user has a known `created_at`."""
+    created = [u.created_at for u in users if u.created_at]
+    if not created:
+        return None
+    earliest_ms = min(created)
+    if earliest_ms > now_ms:
+        earliest_ms = now_ms
+
+    added_counts: dict = {}
+    deleted_counts: dict = {}
+    for u in users:
+        if u.created_at:
+            k = format_time_key(_ms_to_dt(u.created_at), units)
+            added_counts[k] = added_counts.get(k, 0) + 1
+        if u.deleted_at:
+            k = format_time_key(_ms_to_dt(u.deleted_at), units)
+            deleted_counts[k] = deleted_counts.get(k, 0) + 1
+
+    return [
+        {
+            "key": key,
+            "values": {
+                "added": added_counts.get(key, 0),
+                "deleted": deleted_counts.get(key, 0),
+            },
+        }
+        for key in _bucket_keys(earliest_ms, now_ms, units)
+    ]
+
+
+def workspace_churn_series(
+    users: "list[UserRecord]", units: str, now_ms: int
+) -> "list[dict] | None":
+    """Per-bucket workspace churn (proxy, since chargeback has no direct
+    workspace lifecycle). A workspace's `added` bucket is its earliest member
+    `created_at`; its `deleted` bucket is the latest member `deleted_at`, but
+    only when EVERY member has been deleted (best-effort). Returns `None` when
+    no workspace membership is present."""
+    ws_members: dict = {}
+    for u in users:
+        for ws in u.workspaces:
+            ws_members.setdefault(ws, []).append(u)
+    if not ws_members:
+        return None
+
+    added_counts: dict = {}
+    deleted_counts: dict = {}
+    earliest_ms = None
+    for members in ws_members.values():
+        created = [m.created_at for m in members if m.created_at]
+        if not created:
+            continue
+        first_ms = min(created)
+        earliest_ms = first_ms if earliest_ms is None else min(earliest_ms, first_ms)
+        k = format_time_key(_ms_to_dt(first_ms), units)
+        added_counts[k] = added_counts.get(k, 0) + 1
+        deleted = [m.deleted_at for m in members]
+        if deleted and all(d is not None for d in deleted):
+            dk = format_time_key(_ms_to_dt(max(deleted)), units)
+            deleted_counts[dk] = deleted_counts.get(dk, 0) + 1
+
+    if earliest_ms is None:
+        return None
+    if earliest_ms > now_ms:
+        earliest_ms = now_ms
+
+    return [
+        {
+            "key": key,
+            "values": {
+                "added": added_counts.get(key, 0),
+                "deleted": deleted_counts.get(key, 0),
+            },
+        }
+        for key in _bucket_keys(earliest_ms, now_ms, units)
+    ]
+
+
+def em_user_breakdown_series(
+    users: "list[UserRecord]", units: str, now_ms: int, active_window_days: int
+) -> "list[dict] | None":
+    """Per-bucket EM user breakdown: `active` (`em_last_used_at` within the
+    rolling window), `experimenters` (`experiment_count` > 0), `data_pushers`
+    (`data_logged_mb` > 0). Experimenter / data-pusher counts use the snapshot
+    cumulative totals, so a user is counted from the bucket they first exist
+    (an approximation that matches the client notebook). Returns `None` when
+    there is no EM signal at all."""
+    has_em = any(
+        u.em_last_used_at is not None
+        or (u.experiment_count or 0) > 0
+        or (u.data_logged_mb or 0) > 0
+        for u in users
+    )
+    if not has_em:
+        return None
+    window_ms = active_window_days * 86400 * 1000
+    points = []
+    for key, bucket_end_ms, existing in _iter_buckets(users, units, now_ms):
+        active = sum(
+            1
+            for u in existing
+            if _within_window(u.em_last_used_at, bucket_end_ms, window_ms)
+        )
+        experimenters = sum(1 for u in existing if (u.experiment_count or 0) > 0)
+        data_pushers = sum(1 for u in existing if (u.data_logged_mb or 0) > 0)
+        points.append(
+            {
+                "key": key,
+                "values": {
+                    "active": active,
+                    "experimenters": experimenters,
+                    "data_pushers": data_pushers,
+                },
+            }
+        )
+    return points
+
+
+def opik_user_breakdown_series(
+    users: "list[UserRecord]", units: str, now_ms: int, active_window_days: int
+) -> "list[dict] | None":
+    """Per-bucket Opik user breakdown: `active` (`opik_last_used_at` within the
+    rolling window) and `span_producers` (`opik_span_count` > 0, snapshot
+    cumulative). Returns `None` when there is no Opik signal at all."""
+    has_opik = any(
+        u.opik_last_used_at is not None or (u.opik_span_count or 0) > 0 for u in users
+    )
+    if not has_opik:
+        return None
+    window_ms = active_window_days * 86400 * 1000
+    points = []
+    for key, bucket_end_ms, existing in _iter_buckets(users, units, now_ms):
+        active = sum(
+            1
+            for u in existing
+            if _within_window(u.opik_last_used_at, bucket_end_ms, window_ms)
+        )
+        span_producers = sum(1 for u in existing if (u.opik_span_count or 0) > 0)
+        points.append(
+            {
+                "key": key,
+                "values": {"active": active, "span_producers": span_producers},
+            }
+        )
+    return points
+
+
+@dataclasses.dataclass(frozen=True)
+class WorkspaceRecord:
+    """A workspace as reported by the chargeback report's `workspaces[]`."""
+
+    name: str
+    num_experiments: float
+    data_mb: float
+    num_projects: int
+    members: "list"  # member usernames
+
+
+def parse_workspaces(chargeback: dict) -> "list[WorkspaceRecord]":
+    """Parse `chargeback["workspaces"]` into `WorkspaceRecord`s. `projects` may
+    be a list (its length is the project count) or already a number; both are
+    tolerated. These are EM/experiment projects -- chargeback does not carry
+    Opik projects or MPM models."""
+    out = []
+    for w in (chargeback or {}).get("workspaces") or []:
+        projects = w.get("projects")
+        if isinstance(projects, list):
+            num_projects = len(projects)
+        elif isinstance(projects, (int, float)):
+            num_projects = int(projects)
+        else:
+            num_projects = 0
+        members = [
+            m.get("userName") for m in (w.get("members") or []) if m.get("userName")
+        ]
+        out.append(
+            WorkspaceRecord(
+                name=w.get("name"),
+                num_experiments=w.get("numberOfExperiments") or 0,
+                data_mb=w.get("totalSizeInMb") or 0.0,
+                num_projects=num_projects,
+                members=members,
+            )
+        )
+    return out
+
+
+def workspace_org_totals(workspaces: "list[WorkspaceRecord]") -> dict:
+    """Org-wide totals across all workspaces (from chargeback)."""
+    return {
+        "workspaces": len(workspaces),
+        "projects": sum(w.num_projects for w in workspaces),
+        "experiments": sum(w.num_experiments for w in workspaces),
+        "data_mb": sum(w.data_mb for w in workspaces),
+    }
+
+
+def platform_mix(
+    workspaces: "list[WorkspaceRecord]", users: "list[UserRecord]"
+) -> dict:
+    """Classify each workspace by platform usage into EM-only / Opik-only /
+    both / neither.
+
+    EM = the workspace has experiments or projects (chargeback, reliable).
+    Opik = a member has `opik_span_count > 0`. This is a PROXY: chargeback
+    carries Opik usage only per-user, so a user active in several workspaces
+    has their Opik usage attributed to all of them (possible false positives).
+    MPM is absent from chargeback and is NOT classified here."""
+    opik_ws = set()
+    for u in users:
+        if (u.opik_span_count or 0) > 0:
+            opik_ws.update(u.workspaces)
+    counts = {"em_only": 0, "opik_only": 0, "both": 0, "neither": 0}
+    for w in workspaces:
+        em = (w.num_experiments or 0) > 0 or w.num_projects > 0
+        op = w.name in opik_ws
+        if em and op:
+            counts["both"] += 1
+        elif em:
+            counts["em_only"] += 1
+        elif op:
+            counts["opik_only"] += 1
+        else:
+            counts["neither"] += 1
+    return counts

--- a/cometx/cli/migrate_users.py
+++ b/cometx/cli/migrate_users.py
@@ -218,10 +218,9 @@ def _add_member(url, headers, email, workspace_name):
         except ValueError:
             error_msg = response.text
 
-        is_already_member = (
-            isinstance(error_msg, dict)
-            and "already member of" in error_msg.get("msg", "")
-        )
+        is_already_member = isinstance(
+            error_msg, dict
+        ) and "already member of" in error_msg.get("msg", "")
         if is_already_member:
             return "already_member", None
 
@@ -379,8 +378,7 @@ def migrate_users(parsed_args):
             if ws_failed:
                 parts.append(f"{ws_failed} failed")
             print(
-                parts[0]
-                + (" (" + ", ".join(parts[1:]) + ")" if len(parts) > 1 else "")
+                parts[0] + (" (" + ", ".join(parts[1:]) + ")" if len(parts) > 1 else "")
             )
 
     print(f"\n{'=' * 60}")

--- a/cometx/cli/migrate_users.py
+++ b/cometx/cli/migrate_users.py
@@ -30,9 +30,10 @@ import base64
 import json
 import os
 import sys
-import urllib.parse
 
 import requests
+
+from cometx.utils import InvalidServerURLError, validate_server_base
 
 ADDITIONAL_ARGS = False
 
@@ -101,18 +102,16 @@ def _resolve_server_url(api_key, explicit_url=None):
     3. Error — no silent fallback to cloud URL.
     """
     if explicit_url:
-        # Same rule as `admin_api_url` (the authority) and `_RequestsClient.get`:
-        # accept http(s) with a host, reject only clearly-malformed values.
-        # Requiring https here would have rejected the on-prem http bases those
-        # two accept -- and that an API key's embedded baseUrl (branch 2 below)
-        # already passes through unchecked, so --url was the stricter path for
-        # no reason. Checked up front so a typo fails before any request.
-        parsed = urllib.parse.urlparse(explicit_url)
-        if parsed.scheme not in ("http", "https") or not parsed.netloc:
-            print(
-                "[ERROR] --url/--source-url must be an http(s):// URL with a "
-                "host; got %r." % explicit_url
-            )
+        # One shared rule (`validate_server_base`) across all three call sites,
+        # so --url, the request boundary, and admin_api_url can't drift into
+        # accepting different bases. Requiring https here would have rejected
+        # the on-prem http bases the other two accept -- and that an API key's
+        # embedded baseUrl (branch 2 below) already passes through unchecked.
+        # Checked up front so a typo fails before any request is issued.
+        try:
+            validate_server_base(explicit_url, label="--url/--source-url")
+        except InvalidServerURLError as e:
+            print("[ERROR] %s" % e)
             sys.exit(1)
         return explicit_url.rstrip("/")
 
@@ -146,19 +145,11 @@ class _RequestsClient:
     """
 
     def get(self, url, headers=None, params=None):
-        # Defensive sanity check at the request boundary: callers derive
-        # `url` from operator-supplied --url/--source-url. Reject only
-        # clearly-malformed values (no host, or a non-http(s) scheme) rather
-        # than handing an arbitrary value to requests.get. On-prem Comet
-        # servers are reachable over plain http (see MIGRATIONS.md), so http
-        # is allowed; this is not an SSRF denylist.
-        from cometx.utils import InvalidServerURLError
-
-        parsed = urllib.parse.urlparse(url)
-        if parsed.scheme not in ("http", "https") or not parsed.netloc:
-            raise InvalidServerURLError(
-                "Request URL must be an http(s):// URL with a host; got %r." % url
-            )
+        # Defensive sanity check at the request boundary, using the same shared
+        # rule as --url and admin_api_url: callers derive `url` from
+        # operator-supplied --url/--source-url, so reject clearly-malformed
+        # values rather than handing an arbitrary one to requests.get.
+        validate_server_base(url, label="Request URL")
         resp = requests.get(url, headers=headers, params=params, timeout=30)
         resp.raise_for_status()
         return resp
@@ -291,10 +282,6 @@ def migrate_users(parsed_args):
                 "[WARNING] Source and destination URL and API key are identical. "
                 "Are you sure you want to migrate users to the same environment?"
             )
-        # Imported here (not at module scope) to match `_fetch_chargeback_report`
-        # and keep comet_ml off migrate-users' import path.
-        from cometx.utils import InvalidServerURLError
-
         try:
             data = _fetch_chargeback_report(source_url, source_api_key)
         except InvalidServerURLError as e:

--- a/cometx/cli/migrate_users.py
+++ b/cometx/cli/migrate_users.py
@@ -137,6 +137,15 @@ class _RequestsClient:
     """
 
     def get(self, url, headers=None, params=None):
+        # Defensive scheme check at the request boundary: callers derive
+        # `url` from operator-supplied --url/--source-url, and we only ever
+        # talk to a Comet server over https. Reject anything else rather than
+        # handing an arbitrary value to requests.get.
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme != "https" or not parsed.netloc:
+            raise ValueError(
+                "Request URL must be an https:// URL with a host; got %r." % url
+            )
         resp = requests.get(url, headers=headers, timeout=30)
         resp.raise_for_status()
         return resp

--- a/cometx/cli/migrate_users.py
+++ b/cometx/cli/migrate_users.py
@@ -101,9 +101,18 @@ def _resolve_server_url(api_key, explicit_url=None):
     3. Error — no silent fallback to cloud URL.
     """
     if explicit_url:
+        # Same rule as `admin_api_url` (the authority) and `_RequestsClient.get`:
+        # accept http(s) with a host, reject only clearly-malformed values.
+        # Requiring https here would have rejected the on-prem http bases those
+        # two accept -- and that an API key's embedded baseUrl (branch 2 below)
+        # already passes through unchecked, so --url was the stricter path for
+        # no reason. Checked up front so a typo fails before any request.
         parsed = urllib.parse.urlparse(explicit_url)
-        if parsed.scheme != "https":
-            print("[ERROR] --url/--source-url must use https://.")
+        if parsed.scheme not in ("http", "https") or not parsed.netloc:
+            print(
+                "[ERROR] --url/--source-url must be an http(s):// URL with a "
+                "host; got %r." % explicit_url
+            )
             sys.exit(1)
         return explicit_url.rstrip("/")
 

--- a/cometx/cli/migrate_users.py
+++ b/cometx/cli/migrate_users.py
@@ -137,14 +137,16 @@ class _RequestsClient:
     """
 
     def get(self, url, headers=None, params=None):
-        # Defensive scheme check at the request boundary: callers derive
-        # `url` from operator-supplied --url/--source-url, and we only ever
-        # talk to a Comet server over https. Reject anything else rather than
-        # handing an arbitrary value to requests.get.
+        # Defensive sanity check at the request boundary: callers derive
+        # `url` from operator-supplied --url/--source-url. Reject only
+        # clearly-malformed values (no host, or a non-http(s) scheme) rather
+        # than handing an arbitrary value to requests.get. On-prem Comet
+        # servers are reachable over plain http (see MIGRATIONS.md), so http
+        # is allowed; this is not an SSRF denylist.
         parsed = urllib.parse.urlparse(url)
-        if parsed.scheme != "https" or not parsed.netloc:
+        if parsed.scheme not in ("http", "https") or not parsed.netloc:
             raise ValueError(
-                "Request URL must be an https:// URL with a host; got %r." % url
+                "Request URL must be an http(s):// URL with a host; got %r." % url
             )
         resp = requests.get(url, headers=headers, params=params, timeout=30)
         resp.raise_for_status()
@@ -161,9 +163,12 @@ class _ApiShim:
 
 
 def _fetch_chargeback_report(server_url, source_api_key):
-    from cometx.utils import fetch_chargeback_report
+    from cometx.utils import admin_api_url, fetch_chargeback_report
 
-    url = f"{server_url}/api/admin/chargeback/report"
+    # Build the printed URL the same way fetch_chargeback_report builds the
+    # one it requests (preserving any path prefix), so the debug line can't
+    # drift from the URL actually hit.
+    url = admin_api_url(server_url, "/api/admin/chargeback/report")
     print(f"Fetching chargeback report from {url}...")
     api = _ApiShim(server_url, source_api_key)
     return fetch_chargeback_report(api, host=server_url)

--- a/cometx/cli/migrate_users.py
+++ b/cometx/cli/migrate_users.py
@@ -282,6 +282,13 @@ def migrate_users(parsed_args):
             )
         try:
             data = _fetch_chargeback_report(source_url, source_api_key)
+        except ValueError as e:
+            # admin_api_url() rejects a malformed base. source_url may come
+            # from an API key's embedded baseUrl (see _resolve_server_url),
+            # which isn't validated up front -- surface it as a clean CLI
+            # error rather than letting the ValueError crash with a traceback.
+            print(f"[ERROR] Invalid source server URL: {e}")
+            sys.exit(1)
         except requests.exceptions.RequestException as e:
             print(f"[ERROR] Failed to fetch chargeback report: {e}")
             sys.exit(1)

--- a/cometx/cli/migrate_users.py
+++ b/cometx/cli/migrate_users.py
@@ -143,9 +143,11 @@ class _RequestsClient:
         # than handing an arbitrary value to requests.get. On-prem Comet
         # servers are reachable over plain http (see MIGRATIONS.md), so http
         # is allowed; this is not an SSRF denylist.
+        from cometx.utils import InvalidServerURLError
+
         parsed = urllib.parse.urlparse(url)
         if parsed.scheme not in ("http", "https") or not parsed.netloc:
-            raise ValueError(
+            raise InvalidServerURLError(
                 "Request URL must be an http(s):// URL with a host; got %r." % url
             )
         resp = requests.get(url, headers=headers, params=params, timeout=30)
@@ -280,17 +282,32 @@ def migrate_users(parsed_args):
                 "[WARNING] Source and destination URL and API key are identical. "
                 "Are you sure you want to migrate users to the same environment?"
             )
+        # Imported here (not at module scope) to match `_fetch_chargeback_report`
+        # and keep comet_ml off migrate-users' import path.
+        from cometx.utils import InvalidServerURLError
+
         try:
             data = _fetch_chargeback_report(source_url, source_api_key)
-        except ValueError as e:
+        except InvalidServerURLError as e:
             # admin_api_url() rejects a malformed base. source_url may come
             # from an API key's embedded baseUrl (see _resolve_server_url),
             # which isn't validated up front -- surface it as a clean CLI
-            # error rather than letting the ValueError crash with a traceback.
+            # error rather than letting it crash with a traceback. Matched on
+            # its own type so a non-JSON 200 (json.JSONDecodeError, also a
+            # ValueError) isn't misreported as a bad URL.
             print(f"[ERROR] Invalid source server URL: {e}")
             sys.exit(1)
         except requests.exceptions.RequestException as e:
             print(f"[ERROR] Failed to fetch chargeback report: {e}")
+            sys.exit(1)
+        except ValueError as e:
+            # json.JSONDecodeError from response.json(): the endpoint answered
+            # 2xx with a non-JSON body, typically an SSO/reverse-proxy HTML
+            # login page in front of the Comet server.
+            print(
+                "[ERROR] The chargeback endpoint did not return JSON "
+                f"(is {source_url} behind a login/proxy?): {e}"
+            )
             sys.exit(1)
 
     workspaces = data.get("workspaces", [])

--- a/cometx/cli/migrate_users.py
+++ b/cometx/cli/migrate_users.py
@@ -33,7 +33,11 @@ import sys
 
 import requests
 
-from cometx.utils import InvalidServerURLError, validate_server_base
+from cometx.utils import (
+    InvalidServerURLError,
+    redact_url_userinfo,
+    validate_server_base,
+)
 
 ADDITIONAL_ARGS = False
 
@@ -169,9 +173,10 @@ def _fetch_chargeback_report(server_url, source_api_key):
 
     # Build the printed URL the same way fetch_chargeback_report builds the
     # one it requests (preserving any path prefix), so the debug line can't
-    # drift from the URL actually hit.
+    # drift from the URL actually hit. Printed with userinfo redacted: a base
+    # like https://user:pass@host would otherwise put credentials on screen.
     url = admin_api_url(server_url, "/api/admin/chargeback/report")
-    print(f"Fetching chargeback report from {url}...")
+    print(f"Fetching chargeback report from {redact_url_userinfo(url)}...")
     api = _ApiShim(server_url, source_api_key)
     return fetch_chargeback_report(api, host=server_url)
 
@@ -270,13 +275,15 @@ def migrate_users(parsed_args):
         sys.exit(1)
 
     dest_url = _resolve_server_url(api_key, parsed_args.url)
-    print(f"Destination URL: {dest_url}")
+    # Redacted on the way out only -- dest_url itself keeps any userinfo so
+    # requests to a deployment relying on it still authenticate.
+    print(f"Destination URL: {redact_url_userinfo(dest_url)}")
 
     if parsed_args.chargeback_report:
         data = _load_chargeback_report(parsed_args.chargeback_report)
     else:
         source_url = _resolve_server_url(source_api_key, parsed_args.source_url)
-        print(f"Source URL: {source_url}")
+        print(f"Source URL: {redact_url_userinfo(source_url)}")
         if source_url == dest_url and source_api_key == api_key:
             print(
                 "[WARNING] Source and destination URL and API key are identical. "
@@ -302,7 +309,7 @@ def migrate_users(parsed_args):
             # login page in front of the Comet server.
             print(
                 "[ERROR] The chargeback endpoint did not return JSON "
-                f"(is {source_url} behind a login/proxy?): {e}"
+                f"(is {redact_url_userinfo(source_url)} behind a login/proxy?): {e}"
             )
             sys.exit(1)
 

--- a/cometx/cli/migrate_users.py
+++ b/cometx/cli/migrate_users.py
@@ -146,7 +146,7 @@ class _RequestsClient:
             raise ValueError(
                 "Request URL must be an https:// URL with a host; got %r." % url
             )
-        resp = requests.get(url, headers=headers, timeout=30)
+        resp = requests.get(url, headers=headers, params=params, timeout=30)
         resp.raise_for_status()
         return resp
 

--- a/cometx/cli/migrate_users.py
+++ b/cometx/cli/migrate_users.py
@@ -125,16 +125,39 @@ def _resolve_server_url(api_key, explicit_url=None):
     sys.exit(1)
 
 
+class _RequestsClient:
+    """Minimal `api._client`-shaped wrapper around `requests`.
+
+    Lets `fetch_chargeback_report` (which expects a comet_ml-API-like object)
+    be reused here without pulling in comet_ml's own API key parsing, which
+    doesn't apply to migrate-users' server_url/source_api_key inputs. Keeps
+    the existing timeout and raise_for_status behavior so callers of
+    `_fetch_chargeback_report` still see `requests.exceptions.RequestException`
+    on HTTP errors.
+    """
+
+    def get(self, url, headers=None, params=None):
+        resp = requests.get(url, headers=headers, timeout=30)
+        resp.raise_for_status()
+        return resp
+
+
+class _ApiShim:
+    """Minimal comet_ml-API-shaped object for `fetch_chargeback_report`."""
+
+    def __init__(self, url, key):
+        self.config = {"comet.url_override": url}
+        self.api_key = key
+        self._client = _RequestsClient()
+
+
 def _fetch_chargeback_report(server_url, source_api_key):
+    from cometx.utils import fetch_chargeback_report
+
     url = f"{server_url}/api/admin/chargeback/report"
     print(f"Fetching chargeback report from {url}...")
-    resp = requests.get(
-        url,
-        headers={"Authorization": source_api_key},
-        timeout=30,
-    )
-    resp.raise_for_status()
-    return resp.json()
+    api = _ApiShim(server_url, source_api_key)
+    return fetch_chargeback_report(api, host=server_url)
 
 
 def _load_chargeback_report(path):

--- a/cometx/utils.py
+++ b/cometx/utils.py
@@ -387,6 +387,19 @@ def remove_extra_slashes(path):
         return ""
 
 
+class InvalidServerURLError(ValueError):
+    """Raised by `admin_api_url` when the operator-supplied server base is
+    malformed.
+
+    A distinct type (rather than a bare `ValueError`) so callers can tell a
+    URL/config problem apart from the other `ValueError` subclasses that can
+    surface from the same call site -- notably `json.JSONDecodeError`, which
+    `response.json()` raises when a server answers 200 with a non-JSON body
+    (an SSO/reverse-proxy HTML login page). Subclasses `ValueError` so
+    existing `except ValueError` callers keep working.
+    """
+
+
 def admin_api_url(base, path):
     """Join an operator-supplied server base with an admin API `path`.
 
@@ -400,7 +413,7 @@ def admin_api_url(base, path):
     """
     parsed = urlparse(base)
     if parsed.scheme not in ("http", "https") or not parsed.netloc:
-        raise ValueError(
+        raise InvalidServerURLError(
             "Comet server URL must be an http(s):// URL with a host; got %r." % base
         )
     prefix = parsed.path.rstrip("/")

--- a/cometx/utils.py
+++ b/cometx/utils.py
@@ -387,35 +387,52 @@ def remove_extra_slashes(path):
         return ""
 
 
+# The one place the accepted-scheme rule is written down.
+ALLOWED_SERVER_SCHEMES = ("http", "https")
+
+
 class InvalidServerURLError(ValueError):
-    """Raised by `admin_api_url` when the operator-supplied server base is
-    malformed.
+    """Raised when an operator-supplied Comet server URL is malformed.
 
     A distinct type (rather than a bare `ValueError`) so callers can tell a
     URL/config problem apart from the other `ValueError` subclasses that can
     surface from the same call site -- notably `json.JSONDecodeError`, which
-    `response.json()` raises when a server answers 200 with a non-JSON body
+    `response.json()` raises when a server answers 2xx with a non-JSON body
     (an SSO/reverse-proxy HTML login page). Subclasses `ValueError` so
     existing `except ValueError` callers keep working.
     """
 
 
+def validate_server_base(url, label="Comet server URL"):
+    """Validate an operator-supplied server base and return its parse result.
+
+    The single shared rule behind `admin_api_url`, migrate-users'
+    `--url`/`--source-url`, and its request boundary, so those three can't
+    drift into accepting different bases. Accepts http(s) with a host and
+    rejects only clearly-malformed values (no scheme, non-http(s) scheme, or
+    empty host). `label` names the offending input in the error message.
+
+    This is a boundary sanity check, NOT an SSRF control: it intentionally does
+    not denylist private/loopback hosts, since operators legitimately point
+    these admin commands at internal addresses. On-prem Comet servers are
+    reached over plain http, which is why https is not required.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ALLOWED_SERVER_SCHEMES or not parsed.netloc:
+        raise InvalidServerURLError(
+            "%s must be an http(s):// URL with a host; got %r." % (label, url)
+        )
+    return parsed
+
+
 def admin_api_url(base, path):
     """Join an operator-supplied server base with an admin API `path`.
 
-    Validates that `base` is a well-formed http(s) URL with a host, then
-    preserves its scheme, host, AND any path prefix (e.g. `/clientlib`) that
-    on-prem deployments sit behind -- only clearly-malformed values (no
-    scheme, non-http(s) scheme, or empty host) are rejected. This is a
-    boundary sanity check, not an SSRF control: it intentionally does not
-    denylist private/loopback hosts, since operators legitimately point these
-    admin commands at internal addresses.
+    Validates `base` via the shared `validate_server_base`, then preserves its
+    scheme, host, AND any path prefix (e.g. `/clientlib`) that on-prem
+    deployments sit behind.
     """
-    parsed = urlparse(base)
-    if parsed.scheme not in ("http", "https") or not parsed.netloc:
-        raise InvalidServerURLError(
-            "Comet server URL must be an http(s):// URL with a host; got %r." % base
-        )
+    parsed = validate_server_base(base)
     prefix = parsed.path.rstrip("/")
     return "%s://%s%s%s" % (parsed.scheme, parsed.netloc, prefix, path)
 

--- a/cometx/utils.py
+++ b/cometx/utils.py
@@ -410,7 +410,10 @@ def fetch_chargeback_report(api, host=None, report_month=None):
         )
     base = "%s://%s" % (parsed.scheme, parsed.netloc)
     url = base + "/api/admin/chargeback/report"
-    if report_month:
-        url += "?reportMonth=%s" % report_month
-    response = api._client.get(url, headers={"Authorization": api.api_key}, params={})
+    # Pass reportMonth as a query param so it's URL-encoded rather than
+    # interpolated raw into the URL.
+    params = {"reportMonth": report_month} if report_month else {}
+    response = api._client.get(
+        url, headers={"Authorization": api.api_key}, params=params
+    )
     return response.json()

--- a/cometx/utils.py
+++ b/cometx/utils.py
@@ -13,6 +13,7 @@
 
 import base64
 import os
+import re
 import sys
 import time
 from datetime import datetime, timedelta
@@ -390,6 +391,36 @@ def remove_extra_slashes(path):
 # The one place the accepted-scheme rule is written down.
 ALLOWED_SERVER_SCHEMES = ("http", "https")
 
+# `scheme://userinfo@` anywhere in the value -- unanchored so a URL quoted in
+# the middle of an exception message is caught too. The userinfo class excludes
+# `/?#` and whitespace so an `@` later in a path, query, or sentence can't be
+# mistaken for credentials.
+_SCHEME_USERINFO_RE = re.compile(
+    r"(?P<scheme>[A-Za-z][A-Za-z0-9+.\-]*://)(?P<info>[^/?#@\s]+)@"
+)
+# A scheme-less base (`user:pass@host`), only at the very start of the value.
+_BARE_USERINFO_RE = re.compile(r"^[^/?#@\s]+@")
+
+
+def redact_url_userinfo(value):
+    """Replace any `user:password@` userinfo in `value` with `***@`.
+
+    Operators can legitimately point these admin commands at a base URL
+    carrying credentials (`https://user:pass@comet.internal`). Those must never
+    reach the terminal or a log, so run every URL through this before printing
+    it or embedding it in an error message. Accepts free text as well as a bare
+    URL, since SDK/HTTP exceptions routinely quote the request URL.
+
+    The URL actually requested is left intact -- stripping userinfo there would
+    break a deployment relying on it for proxy/basic auth, and the credentials
+    are bound for that host either way.
+    """
+    if not isinstance(value, str) or "@" not in value:
+        return value
+    return _BARE_USERINFO_RE.sub(
+        "***@", _SCHEME_USERINFO_RE.sub(lambda m: m.group("scheme") + "***@", value)
+    )
+
 
 class InvalidServerURLError(ValueError):
     """Raised when an operator-supplied Comet server URL is malformed.
@@ -410,7 +441,9 @@ def validate_server_base(url, label="Comet server URL"):
     `--url`/`--source-url`, and its request boundary, so those three can't
     drift into accepting different bases. Accepts http(s) with a host and
     rejects only clearly-malformed values (no scheme, non-http(s) scheme, or
-    empty host). `label` names the offending input in the error message.
+    empty host). `label` names the offending input in the error message, whose
+    echo of the value is passed through `redact_url_userinfo` so a base carrying
+    credentials can't leak them into the terminal or a log.
 
     This is a boundary sanity check, NOT an SSRF control: it intentionally does
     not denylist private/loopback hosts, since operators legitimately point
@@ -420,7 +453,8 @@ def validate_server_base(url, label="Comet server URL"):
     parsed = urlparse(url)
     if parsed.scheme not in ALLOWED_SERVER_SCHEMES or not parsed.netloc:
         raise InvalidServerURLError(
-            "%s must be an http(s):// URL with a host; got %r." % (label, url)
+            "%s must be an http(s):// URL with a host; got %r."
+            % (label, redact_url_userinfo(url))
         )
     return parsed
 

--- a/cometx/utils.py
+++ b/cometx/utils.py
@@ -16,6 +16,7 @@ import os
 import sys
 import time
 from datetime import datetime, timedelta
+from urllib.parse import urlparse
 
 import six
 from comet_ml.config import get_config
@@ -384,3 +385,25 @@ def remove_extra_slashes(path):
         return path
     else:
         return ""
+
+
+def fetch_chargeback_report(api, host=None, report_month=None):
+    """Fetch the admin chargeback report JSON.
+
+    Single source for the `/api/admin/chargeback/report` call used by the
+    chargeback-report action, migrate-users, and growth-report. `host`
+    overrides the base URL derived from `api.config["comet.url_override"]`;
+    `report_month` (YYYY-MM) adds `?reportMonth=`.
+    """
+    if host is not None:
+        base = host
+    else:
+        parsed = urlparse(api.config["comet.url_override"])
+        base = "%s://%s" % (parsed.scheme, parsed.netloc)
+    while base.endswith("/"):
+        base = base[:-1]
+    url = base + "/api/admin/chargeback/report"
+    if report_month:
+        url += "?reportMonth=%s" % report_month
+    response = api._client.get(url, headers={"Authorization": api.api_key}, params={})
+    return response.json()

--- a/cometx/utils.py
+++ b/cometx/utils.py
@@ -387,29 +387,40 @@ def remove_extra_slashes(path):
         return ""
 
 
+def admin_api_url(base, path):
+    """Join an operator-supplied server base with an admin API `path`.
+
+    Validates that `base` is a well-formed http(s) URL with a host, then
+    preserves its scheme, host, AND any path prefix (e.g. `/clientlib`) that
+    on-prem deployments sit behind -- only clearly-malformed values (no
+    scheme, non-http(s) scheme, or empty host) are rejected. This is a
+    boundary sanity check, not an SSRF control: it intentionally does not
+    denylist private/loopback hosts, since operators legitimately point these
+    admin commands at internal addresses.
+    """
+    parsed = urlparse(base)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise ValueError(
+            "Comet server URL must be an http(s):// URL with a host; got %r." % base
+        )
+    prefix = parsed.path.rstrip("/")
+    return "%s://%s%s%s" % (parsed.scheme, parsed.netloc, prefix, path)
+
+
 def fetch_chargeback_report(api, host=None, report_month=None):
     """Fetch the admin chargeback report JSON.
 
     Single source for the `/api/admin/chargeback/report` call used by the
     chargeback-report action, migrate-users, and growth-report. `host`
     overrides the base URL derived from `api.config["comet.url_override"]`;
-    `report_month` (YYYY-MM) adds `?reportMonth=`.
+    `report_month` (YYYY-MM) adds `?reportMonth=`. The base's path prefix (if
+    any) is preserved -- see `admin_api_url`.
     """
     if host is not None:
         base = host
     else:
         base = api.config["comet.url_override"]
-    # Require a well-formed https base before issuing the request. The base
-    # comes from operator-supplied --host/--source-url or the configured
-    # override; enforce a scheme so a malformed value can't be sent verbatim.
-    parsed = urlparse(base)
-    if parsed.scheme != "https" or not parsed.netloc:
-        raise ValueError(
-            "Chargeback server URL must be an https:// URL with a host; "
-            "got %r." % base
-        )
-    base = "%s://%s" % (parsed.scheme, parsed.netloc)
-    url = base + "/api/admin/chargeback/report"
+    url = admin_api_url(base, "/api/admin/chargeback/report")
     # Pass reportMonth as a query param so it's URL-encoded rather than
     # interpolated raw into the URL.
     params = {"reportMonth": report_month} if report_month else {}

--- a/cometx/utils.py
+++ b/cometx/utils.py
@@ -398,10 +398,17 @@ def fetch_chargeback_report(api, host=None, report_month=None):
     if host is not None:
         base = host
     else:
-        parsed = urlparse(api.config["comet.url_override"])
-        base = "%s://%s" % (parsed.scheme, parsed.netloc)
-    while base.endswith("/"):
-        base = base[:-1]
+        base = api.config["comet.url_override"]
+    # Require a well-formed https base before issuing the request. The base
+    # comes from operator-supplied --host/--source-url or the configured
+    # override; enforce a scheme so a malformed value can't be sent verbatim.
+    parsed = urlparse(base)
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise ValueError(
+            "Chargeback server URL must be an https:// URL with a host; "
+            "got %r." % base
+        )
+    base = "%s://%s" % (parsed.scheme, parsed.netloc)
     url = base + "/api/admin/chargeback/report"
     if report_month:
         url += "?reportMonth=%s" % report_month

--- a/tests/unit/test_admin_growth_render.py
+++ b/tests/unit/test_admin_growth_render.py
@@ -9,21 +9,30 @@ def test_lines_kind_registered_and_panel_renders():
             "people": {
                 "title": "Users / People",
                 "kpis": [],
-                "charts": [{
-                    "id": "chart-people-adoption",
-                    "kind": "lines",
-                    "title": "Adoption rate",
-                    "data": {
-                        "categories": ["overall", "opik"],
-                        "labels": {"overall": "Overall", "opik": "Opik"},
-                        "colors": ["--accent", "--ok"],
-                        "points": [
-                            {"key": "2026-06", "values": {"overall": 10.0, "opik": 4.0}},
-                            {"key": "2026-07", "values": {"overall": 12.0, "opik": 6.0}},
-                        ],
-                        "window_start": None, "window_end": None,
-                    },
-                }],
+                "charts": [
+                    {
+                        "id": "chart-people-adoption",
+                        "kind": "lines",
+                        "title": "Adoption rate",
+                        "data": {
+                            "categories": ["overall", "opik"],
+                            "labels": {"overall": "Overall", "opik": "Opik"},
+                            "colors": ["--accent", "--ok"],
+                            "points": [
+                                {
+                                    "key": "2026-06",
+                                    "values": {"overall": 10.0, "opik": 4.0},
+                                },
+                                {
+                                    "key": "2026-07",
+                                    "values": {"overall": 12.0, "opik": 6.0},
+                                },
+                            ],
+                            "window_start": None,
+                            "window_end": None,
+                        },
+                    }
+                ],
                 "table": None,
             }
         },

--- a/tests/unit/test_admin_growth_render.py
+++ b/tests/unit/test_admin_growth_render.py
@@ -42,3 +42,135 @@ def test_lines_kind_registered_and_panel_renders():
     assert 'data-kind="lines"' in html
     assert "function drawLines" in html
     assert 'c.kind === "lines"' in html
+
+
+def test_barsline_kind_registered_and_panel_renders():
+    from cometx.cli.admin_growth_render import build_html
+
+    report = {
+        "meta": {"title": "T", "generated": "2026-07-01", "source": "x"},
+        "window": {"label": "w"},
+        "sections": {
+            "unified": {
+                "title": "Organization overview (chargeback)",
+                "kpis": [],
+                "charts": [
+                    {
+                        "id": "chart-unified-workspace-churn",
+                        "kind": "barsLine",
+                        "title": "Workspaces added vs. deleted",
+                        "data": {
+                            "points": [
+                                {
+                                    "key": "2026-06",
+                                    "values": {
+                                        "added": 3,
+                                        "deleted": 1,
+                                        "rate": 50.0,
+                                    },
+                                },
+                                {
+                                    "key": "2026-07",
+                                    "values": {
+                                        "added": 2,
+                                        "deleted": 0,
+                                        "rate": 33.3,
+                                    },
+                                },
+                            ],
+                            "bars": ["added", "deleted"],
+                            "line": "rate",
+                            "bar_colors": ["--ok", "--warn"],
+                            "line_color": "--accent",
+                            "line_suffix": "%",
+                        },
+                    }
+                ],
+                "table": None,
+            }
+        },
+    }
+    html = build_html(report)
+    assert 'id="chart-unified-workspace-churn"' in html
+    assert 'data-kind="barsLine"' in html
+    assert "function drawBarsLine" in html
+    assert 'c.kind === "barsLine"' in html
+    # right-axis helper for the secondary (rate) scale is present and wired
+    assert "function rAxis" in html
+    assert "rAxis(svg, YR" in html
+    # tooltips are attached to the bars+line chart
+    assert "attachTip(host, svg, cols)" in html
+
+
+def test_groupedbarsh_kind_registered_and_panel_renders():
+    from cometx.cli.admin_growth_render import build_html
+
+    report = {
+        "meta": {"title": "T", "generated": "2026-07-01", "source": "x"},
+        "window": {"label": "w"},
+        "sections": {
+            "unified": {
+                "title": "Organization overview (chargeback)",
+                "kpis": [],
+                "charts": [
+                    {
+                        "id": "chart-unified-platform-mix",
+                        "kind": "groupedBarsH",
+                        "title": "Workspace platform mix",
+                        "data": {
+                            "rows": [
+                                {"label": "EM only", "value": 5},
+                                {"label": "Opik only", "value": 2},
+                            ]
+                        },
+                    }
+                ],
+                "table": None,
+            }
+        },
+    }
+    html = build_html(report)
+    assert 'id="chart-unified-platform-mix"' in html
+    assert 'data-kind="groupedBarsH"' in html
+    assert "function drawGroupedH" in html
+    assert 'c.kind === "groupedBarsH"' in html
+
+
+def test_leaderboards_and_personal_vs_service_sections_reach_body():
+    from cometx.cli.admin_growth_render import build_html
+
+    report = {
+        "meta": {"title": "T", "generated": "2026-07-01", "source": "x"},
+        "window": {"label": "w"},
+        "sections": {
+            "leaderboards": {
+                "title": "Leaderboards",
+                "kpis": [],
+                "charts": [],
+                "table": {
+                    "title": "Top users by activity",
+                    "headers": ["User", "Experiments"],
+                    "rows": [["alice", 42]],
+                },
+            },
+            "personal_vs_service": {
+                "title": "Personal vs. service accounts",
+                "kpis": [],
+                "charts": [],
+                "table": {
+                    "title": "Split",
+                    "headers": ["Type", "Count"],
+                    "rows": [["Personal", 10], ["Service", 3]],
+                },
+            },
+        },
+    }
+    html = build_html(report)
+    body = html.split('id="report-data"')[0]
+    # Both section titles and their table content land in the rendered body,
+    # not merely in the embedded JSON payload.
+    assert "Leaderboards" in body
+    assert "Top users by activity" in body
+    assert "alice" in body
+    assert "Personal vs. service accounts" in body
+    assert "Service" in body

--- a/tests/unit/test_admin_growth_render.py
+++ b/tests/unit/test_admin_growth_render.py
@@ -1,0 +1,35 @@
+def test_lines_kind_registered_and_panel_renders():
+    from cometx.cli.admin_growth_render import build_html
+
+    report = {
+        "meta": {"title": "T", "generated": "2026-07-01", "source": "x"},
+        "window": {"label": "w"},
+        "collectors": {"opik": False, "em": False, "mpm": False},
+        "sections": {
+            "people": {
+                "title": "Users / People",
+                "kpis": [],
+                "charts": [{
+                    "id": "chart-people-adoption",
+                    "kind": "lines",
+                    "title": "Adoption rate",
+                    "data": {
+                        "categories": ["overall", "opik"],
+                        "labels": {"overall": "Overall", "opik": "Opik"},
+                        "colors": ["--accent", "--ok"],
+                        "points": [
+                            {"key": "2026-06", "values": {"overall": 10.0, "opik": 4.0}},
+                            {"key": "2026-07", "values": {"overall": 12.0, "opik": 6.0}},
+                        ],
+                        "window_start": None, "window_end": None,
+                    },
+                }],
+                "table": None,
+            }
+        },
+    }
+    html = build_html(report)
+    assert 'id="chart-people-adoption"' in html
+    assert 'data-kind="lines"' in html
+    assert "function drawLines" in html
+    assert 'c.kind === "lines"' in html

--- a/tests/unit/test_admin_growth_report.py
+++ b/tests/unit/test_admin_growth_report.py
@@ -1280,3 +1280,25 @@ def test_short_api_error_condenses_verbose_sdk_error():
     assert _short_api_error("plain boom") == "plain boom"
     long = "x" * 300
     assert len(_short_api_error(long)) <= 160
+
+
+def test_num_renders_integral_floats_as_int():
+    from cometx.cli.admin_growth_report import _num
+
+    assert _num(3.0) == 3
+    assert isinstance(_num(3.0), int)
+    assert _num(3.5) == 3.5
+    assert _num(7) == 7
+
+
+def test_lb_value_rounds_fractional_metric_and_passes_none():
+    # #5d: leaderboard bar values must render like workspace rows -- an
+    # em_score of 12.7 (data_logged_mb folded in) shows as 13, not 12.7,
+    # and a metric a user lacks (None) stays absent rather than becoming 0.
+    from cometx.cli.admin_growth_report import _lb_value
+
+    assert _lb_value(12.7) == 13
+    assert isinstance(_lb_value(12.7), int)
+    assert _lb_value(4.0) == 4
+    assert _lb_value(None) is None
+    assert _lb_value(9) == 9

--- a/tests/unit/test_admin_growth_report.py
+++ b/tests/unit/test_admin_growth_report.py
@@ -1764,3 +1764,38 @@ def test_generate_growth_report_full_chain_all_platforms(monkeypatch, tmp_path):
     assert "sk-planted-env-secret-should-not-leak" not in content
     assert "sk-api-secret-should-not-leak" not in content
     assert "COMET_API_KEY" not in content
+
+
+def test_people_section_built_from_chargeback():
+    import datetime
+    from cometx.cli.admin_growth_report import GrowthReporter
+
+    api = MagicMock()
+    api.config = {"comet.url_override": "https://c.example.com"}
+    api.api_key = "K"
+    cb = {"workspaces": [], "users": {"licensedUsers": [
+        {"username": "alice", "email": "a@x", "lastUsedAt": 4_000, "createdAt": 1,
+         "experimentCount": 5, "dataLoggedMb": 1.0, "opikSpanCount": 9, "suspended": False},
+    ]}}
+    r = GrowthReporter(api, window="7d", units="month", platforms="em",
+                       active_window="60d", include_users=True, leaderboard_top_n=5)
+    section = r._build_people_section(cb, now_ms=4_500)
+    assert section["title"].startswith("Users")
+    labels = [k["label"] for k in section["kpis"]]
+    assert any("Active" in x for x in labels)
+    assert any("Adoption" in x for x in labels)
+
+
+def test_include_users_false_skips_people(monkeypatch):
+    from cometx.cli.admin_growth_report import GrowthReporter
+    api = MagicMock()
+    r = GrowthReporter(api, window="7d", units="month", platforms="em",
+                       include_users=False)
+    # build() must not call fetch_chargeback_report when include_users is False
+    import cometx.utils as U
+    called = {"n": 0}
+    monkeypatch.setattr(U, "fetch_chargeback_report", lambda *a, **k: called.__setitem__("n", called["n"] + 1) or {})
+    r.api.get_workspaces.return_value = []
+    data = r.build([])
+    assert "people" not in data["sections"]
+    assert called["n"] == 0

--- a/tests/unit/test_admin_growth_report.py
+++ b/tests/unit/test_admin_growth_report.py
@@ -502,6 +502,72 @@ def test_collect_opik_skips_bad_workspace_and_continues(
     assert any(m.workspace == "ws_good" and m.metric == "SPAN_COUNT" for m in usage)
 
 
+@requires_opik
+def test_collect_opik_emits_trace_count_alongside_spans():
+    import datetime
+    from cometx.cli.admin_growth_report import GrowthReporter
+
+    api = MagicMock()
+    api.config = {"comet.api_key": "K", "comet.url_override": "https://c.example.com"}
+
+    proj = MagicMock()
+    proj.name = "proj-1"
+    proj.id = "pid-1"
+    proj.created_at = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
+
+    def _metrics(project_id, metric_type, interval, interval_start, interval_end):
+        dp = MagicMock(time=datetime.datetime(2026, 6, 2, tzinfo=datetime.timezone.utc),
+                       value=(10 if metric_type == "SPAN_COUNT" else 3))
+        result = MagicMock(data=[dp])
+        return MagicMock(results=[result])
+
+    client = MagicMock()
+    page = MagicMock(content=[proj], total=1)
+    client.rest_client.projects.find_projects.return_value = page
+    client.rest_client.projects.get_project_metrics.side_effect = _metrics
+
+    with patch("opik.Opik", return_value=client), \
+         patch("cometx.cli.smoke_test.get_opik_config", return_value="https://c.example.com"):
+        r = GrowthReporter(api, window="7d", units="month", platforms="opik")
+        events, usage = r._collect_opik(["wsA"])
+
+    metrics = {(m.metric, m.project) for m in usage}
+    assert ("SPAN_COUNT", "proj-1") in metrics
+    assert ("TRACE_COUNT", "proj-1") in metrics
+    # workspace roll-ups (project=None) exist for both
+    assert ("SPAN_COUNT", None) in metrics
+    assert ("TRACE_COUNT", None) in metrics
+
+
+@requires_opik
+def test_collect_opik_trace_failure_keeps_spans():
+    import datetime
+    from cometx.cli.admin_growth_report import GrowthReporter
+
+    api = MagicMock()
+    api.config = {"comet.api_key": "K", "comet.url_override": "https://c.example.com"}
+    proj = MagicMock(); proj.name = "p"; proj.id = "id"
+    proj.created_at = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
+
+    def _metrics(project_id, metric_type, interval, interval_start, interval_end):
+        if metric_type == "TRACE_COUNT":
+            raise RuntimeError("traces boom")
+        dp = MagicMock(time=datetime.datetime(2026, 6, 2, tzinfo=datetime.timezone.utc), value=5)
+        return MagicMock(results=[MagicMock(data=[dp])])
+
+    client = MagicMock()
+    client.rest_client.projects.find_projects.return_value = MagicMock(content=[proj], total=1)
+    client.rest_client.projects.get_project_metrics.side_effect = _metrics
+
+    with patch("opik.Opik", return_value=client), \
+         patch("cometx.cli.smoke_test.get_opik_config", return_value="https://c.example.com"):
+        r = GrowthReporter(api, window="7d", units="month", platforms="opik")
+        events, usage = r._collect_opik(["wsA"])
+
+    assert any(m.metric == "SPAN_COUNT" and m.project == "p" for m in usage)
+    assert not any(m.metric == "TRACE_COUNT" and m.project == "p" for m in usage)
+
+
 def test_collect_opik_missing_dependency_returns_empty(monkeypatch):
     import builtins
 

--- a/tests/unit/test_admin_growth_report.py
+++ b/tests/unit/test_admin_growth_report.py
@@ -1122,6 +1122,56 @@ def test_exclude_personal_drops_matching_workspaces_from_chargeback():
     assert len(cb["workspaces"]) == 2
 
 
+def test_units_adverb_avoids_dayly_typo():
+    from cometx.cli.admin_growth_report import GrowthReporter
+
+    api = MagicMock()
+    assert GrowthReporter(api, window="7d", units="day")._units_adverb() == "daily"
+    assert GrowthReporter(api, window="7d", units="week")._units_adverb() == "weekly"
+    assert GrowthReporter(api, window="7d", units="month")._units_adverb() == "monthly"
+    assert GrowthReporter(api, window="7d", units="hour")._units_adverb() == "hourly"
+
+
+def test_scope_label_uses_post_filter_count_not_requested_args():
+    from cometx.cli.admin_growth_report import GrowthReporter
+
+    # three workspaces requested, but only one survives scoping/--exclude-personal
+    label = GrowthReporter._scope_label({"a", "b", "c"}, 100, 50, scoped_count=1)
+    assert label == "Scoped to 1 selected workspace(s)"
+    # falls back to len(scope) when no scoped_count is given
+    assert GrowthReporter._scope_label({"a", "b"}, 100, 50) == (
+        "Scoped to 2 selected workspace(s)"
+    )
+
+
+def test_personal_vs_service_honors_empty_admin_set():
+    # An empty set() from the admin service-accounts API is authoritative
+    # ("zero service accounts"), so the split must report the admin_api source,
+    # NOT fall back to the regex heuristic.
+    from cometx.cli.admin_growth_report import GrowthReporter
+    from cometx.cli.admin_growth_users import parse_users
+
+    cb = {
+        "workspaces": [],
+        "users": {
+            "report": [
+                {
+                    "username": "alice",
+                    "email": "a",
+                    "experimentCount": 5,
+                    "dataLoggedMb": 2.0,
+                    "lastUsedAt": 1,
+                },
+            ]
+        },
+    }
+    api = MagicMock()
+    r = GrowthReporter(api, window="7d", units="month")
+    section = r._build_personal_vs_service_section(parse_users(cb), set())
+    assert section is not None
+    assert "admin API" in section["charts"][0]["hint"]
+
+
 def test_short_api_error_condenses_verbose_sdk_error():
     from cometx.cli.admin_growth_report import _short_api_error
 

--- a/tests/unit/test_admin_growth_report.py
+++ b/tests/unit/test_admin_growth_report.py
@@ -345,6 +345,34 @@ def test_build_html_handles_missing_sections_gracefully():
     assert "<style>" in build_html(None)
 
 
+def test_build_html_has_no_products_or_collectors():
+    from cometx.cli.admin_growth_render import build_html
+
+    report = {
+        "meta": {
+            "title": "T",
+            "generated": "x",
+            "source": "s",
+            "scope": "Org-wide (chargeback)",
+        },
+        "window": {"label": "w"},
+        "sections": {
+            "unified": {
+                "title": "Organization overview (chargeback)",
+                "kpis": [],
+                "charts": [],
+                "table": None,
+            }
+        },
+    }
+    doc = build_html(report)
+    assert "product-heading" not in doc
+    assert 'aria-label="collector status"' not in doc
+    assert "drawStacked" not in doc
+    assert "drawArea" not in doc
+    assert "Organization overview (chargeback)" in doc
+
+
 def test_write_html_writes_file_and_returns_path(tmp_path):
     from cometx.cli.admin_growth_report import write_html
 

--- a/tests/unit/test_admin_growth_report.py
+++ b/tests/unit/test_admin_growth_report.py
@@ -1009,11 +1009,11 @@ def _sample_report_data():
         "collectors": {"opik": True, "em": True, "mpm": False},
         "sections": {
             "unified": {
-                "title": "Use cases across all platforms",
+                "title": "Workspaces & projects",
                 "window_chip": "Analysis window: Jul 2 – Jul 9, 2026 (7d)",
                 "kpis": [
                     {"label": "Workspaces", "value": 4},
-                    {"label": "Use cases", "value": 77, "tone": "ok"},
+                    {"label": "Projects", "value": 77, "tone": "ok"},
                     {"label": "New (7d)", "value": "+12"},
                     {
                         "label": "Growth (7d)",
@@ -1025,7 +1025,7 @@ def _sample_report_data():
                     {
                         "id": "chart-unified-created",
                         "kind": "stackedBars",
-                        "title": "Use cases created",
+                        "title": "Projects created",
                         "hint": "by kind · monthly",
                         "legend": [
                             {"label": "Opik", "color": "--accent"},
@@ -1069,7 +1069,7 @@ def _sample_report_data():
                     {
                         "id": "chart-unified-by-workspace",
                         "kind": "groupedBarsH",
-                        "title": "Use cases by workspace",
+                        "title": "Projects by workspace",
                         "hint": "current totals",
                         "data": {
                             "rows": [
@@ -1211,7 +1211,7 @@ def test_build_html_is_self_contained_and_secure():
     assert 'id="report-data"' in doc
     assert "http://" not in doc
     assert "https://" not in doc
-    assert "Use cases across all platforms" in doc
+    assert "Workspaces & projects" in doc
     assert "<svg" not in doc  # charts are drawn client-side, not server-side
     assert "createElementNS" in doc  # the inline SVG-drawing JS
     assert '"window"' in doc  # the embedded json payload
@@ -1354,7 +1354,7 @@ def test_write_html_writes_file_and_returns_path(tmp_path):
     content = out.read_text(encoding="utf-8")
     assert "<style>" in content
     assert 'id="report-data"' in content
-    assert "Use cases across all platforms" in content
+    assert "Workspaces & projects" in content
 
 
 def test_write_growth_html_delegates_to_renderer(tmp_path):
@@ -1571,25 +1571,32 @@ def test_build_assembles_report_data_matching_c8_contract(monkeypatch):
     assert "7d" in window["label"]
 
     unified = report_data["sections"]["unified"]
-    assert unified["title"] == "Use cases across all platforms"
+    # Chargeback fetch is mocked to fail here, so the section falls back to the
+    # SDK (accessible-workspaces) view.
+    assert unified["title"] == "Workspaces & projects (accessible)"
     kpi_labels = [k["label"] for k in unified["kpis"]]
-    assert "Workspaces" in kpi_labels
+    assert "Total workspaces" in kpi_labels
     assert "Departments" not in kpi_labels
-    assert "Use cases" in kpi_labels
-    use_cases_kpi = next(k for k in unified["kpis"] if k["label"] == "Use cases")
-    assert use_cases_kpi["value"] == 6  # 3 opik + 2 em + 1 mpm
+    assert "Total projects" in kpi_labels
+    projects_kpi = next(k for k in unified["kpis"] if k["label"] == "Total projects")
+    assert projects_kpi["value"] == 6  # 3 opik + 2 em + 1 mpm
 
-    chart_ids = [c["id"] for c in unified["charts"]]
-    assert "chart-unified-created" not in chart_ids or True  # ids are ours
-    kinds_chart = next(c for c in unified["charts"] if c["kind"] == "stackedBars")
+    # projects-created chart is stacked by kind (Opik/EM/MPM projects)
+    kinds_chart = next(
+        c for c in unified["charts"] if c["id"] == "chart-unified-created"
+    )
     assert kinds_chart["data"]["categories"] == [
         "opik_project",
         "em_project",
         "mpm_model",
     ]
-    dept_chart = next(c for c in unified["charts"] if c["kind"] == "groupedBarsH")
-    dept_labels = {r["label"] for r in dept_chart["data"]["rows"]}
-    assert dept_labels == {"ws-alpha", "ws-beta"}
+    # the per-workspace breakdown now lives only in the unified table (the
+    # "Projects by workspace" chart was removed); the summary charts are the
+    # four created/cumulative workspace + project series
+    chart_ids = [c["id"] for c in unified["charts"]]
+    assert "chart-unified-by-workspace" not in chart_ids
+    assert "chart-unified-workspaces-cumulative" in chart_ids
+    assert "chart-unified-projects-cumulative" in chart_ids
 
     # multi-workspace -> unified table breaks down by workspace
     assert unified["table"]["title"] == "By workspace"
@@ -1682,7 +1689,7 @@ def test_build_single_workspace_breaks_down_unified_table_by_use_case(monkeypatc
     report_data = reporter.build(["ws1"])
 
     unified_table = report_data["sections"]["unified"]["table"]
-    assert unified_table["headers"][0] == "Use case"
+    assert unified_table["headers"][0] == "Project"
     assert unified_table["rows"] == [["op1", "Opik projects", "2026-06-01"]]
 
 
@@ -1709,7 +1716,7 @@ def test_generate_growth_report_writes_html_with_no_secret(monkeypatch, tmp_path
 
     content = out.read_text(encoding="utf-8")
     assert path == str(out)
-    assert "Use cases across all platforms" in content
+    assert "Workspaces & projects" in content
     assert "op1" in content or "op2" in content
     assert "sk-should-never-leak-0000" not in content
 
@@ -1763,7 +1770,7 @@ def test_generate_growth_report_full_chain_all_platforms(monkeypatch, tmp_path):
     assert path == str(out)
 
     # Section titles from all three product sections + the unified section.
-    assert "Use cases across all platforms" in content
+    assert "Workspaces & projects" in content
     assert "Opik — growth" in content
     assert "EM — growth" in content
     assert "MPM — growth" in content
@@ -1810,11 +1817,64 @@ def test_people_section_built_from_chargeback():
         include_users=True,
         leaderboard_top_n=5,
     )
-    section = r._build_people_section(cb, now_ms=4_500)
-    assert section["title"].startswith("Users")
+    from cometx.cli.admin_growth_users import parse_users
+
+    section = r._build_people_section(parse_users(cb), now_ms=4_500)
+    assert section["title"] == "Users"
     labels = [k["label"] for k in section["kpis"]]
-    assert any("Active" in x for x in labels)
-    assert any("Adoption" in x for x in labels)
+    assert "Active users %" in labels
+    # workspace metrics moved to the Workspaces & projects section
+    assert "Active workspaces %" not in labels
+    assert any(x.startswith("Active users (") for x in labels)
+
+
+def test_people_section_user_growth_kpi_with_window():
+    from cometx.cli.admin_growth_report import GrowthReporter
+    from cometx.cli.admin_growth_users import parse_users
+
+    before = int(
+        datetime.datetime(2025, 6, 1, tzinfo=datetime.timezone.utc).timestamp() * 1000
+    )
+    in_win = int(
+        datetime.datetime(2026, 3, 1, tzinfo=datetime.timezone.utc).timestamp() * 1000
+    )
+    now_ms = int(
+        datetime.datetime(2026, 7, 1, tzinfo=datetime.timezone.utc).timestamp() * 1000
+    )
+    cb = {
+        "workspaces": [],
+        "users": {
+            "licensedUsers": [
+                {
+                    "username": "old1",
+                    "email": "o1",
+                    "createdAt": before,
+                    "lastUsedAt": now_ms,
+                },
+                {
+                    "username": "old2",
+                    "email": "o2",
+                    "createdAt": before,
+                    "lastUsedAt": now_ms,
+                },
+                {
+                    "username": "new1",
+                    "email": "n1",
+                    "createdAt": in_win,
+                    "lastUsedAt": now_ms,
+                },
+            ]
+        },
+    }
+    api = MagicMock()
+    r = GrowthReporter(
+        api, window="7d", units="month", platforms="em", active_window="60d"
+    )
+    section = r._build_people_section(parse_users(cb), now_ms=now_ms, window=_win())
+    growth = next(k for k in section["kpis"] if k["label"].startswith("New in"))
+    # one new account in-window vs two before => 50%, "+1 new"
+    assert growth["value"] == "50.0%"
+    assert growth["sub"] == "+1 new"
 
 
 def test_include_users_false_skips_people(monkeypatch):
@@ -2239,3 +2299,319 @@ def test_exclude_personal_without_pattern_is_noop():
         personal_pattern=None,
     )
     assert r._filter_personal(["a", "b"]) == ["a", "b"]
+
+
+def test_workspace_first_events_and_cumulative_growth():
+    import datetime
+
+    from cometx.cli.admin_growth_report import CreationEvent, GrowthReporter
+
+    api = MagicMock()
+    api.config = {"comet.url_override": "https://c.example.com"}
+
+    def ev(ws, y, m):
+        return CreationEvent(
+            "opik",
+            ws,
+            f"{ws}-{y}-{m}",
+            "opik_project",
+            datetime.datetime(y, m, 1, tzinfo=datetime.timezone.utc),
+        )
+
+    # A first seen Jan (has a later Feb project too -> must dedup to Jan),
+    # B/C Feb, D Mar -> workspace cumulative total 1,3,4
+    events = [
+        ev("A", 2024, 1),
+        ev("A", 2024, 2),
+        ev("B", 2024, 2),
+        ev("C", 2024, 2),
+        ev("D", 2024, 3),
+    ]
+    r = GrowthReporter(api, window="7d", units="month", platforms="opik")
+
+    ws_events = r._workspace_first_events(events)
+    # one event per workspace, at its earliest month
+    assert {e.workspace: e.created.strftime("%Y-%m") for e in ws_events} == {
+        "A": "2024-01",
+        "B": "2024-02",
+        "C": "2024-02",
+        "D": "2024-03",
+    }
+
+    chart = r._cumulative_area_chart(
+        ws_events, "chart-unified-workspaces-cumulative", "Total workspaces over time"
+    )
+    assert chart["kind"] == "area"
+    totals = {p["key"]: p["value"] for p in chart["data"]["points"]}
+    assert totals == {"2024-01": 1, "2024-02": 3, "2024-03": 4}
+    # no obsolete window band on the growth curve
+    assert chart["data"]["window_start"] is None
+    # a single period is not enough of a trajectory to plot -> no chart
+    assert r._cumulative_area_chart([ev("A", 2024, 1)], "id", "t") is None
+
+
+def _cb_lb():
+    return {
+        "workspaces": [
+            {"name": "team-a", "members": [{"userName": "alice"}, {"userName": "bob"}]},
+            {"name": "team-b", "members": [{"userName": "alice"}]},
+        ],
+        "users": {
+            "licensedUsers": [
+                {
+                    "username": "alice",
+                    "email": "a@x",
+                    "experimentCount": 40,
+                    "dataLoggedMb": 10.0,
+                    "opikSpanCount": 5000,
+                    "lastUsedAt": 1,
+                },
+                {
+                    "username": "bob",
+                    "email": "b@x",
+                    "experimentCount": 1,
+                    "dataLoggedMb": 2.0,
+                    "opikSpanCount": 0,
+                    "lastUsedAt": 1,
+                },
+            ]
+        },
+    }
+
+
+def test_scope_chargeback_filters_workspaces_and_users():
+    from cometx.cli.admin_growth_report import _scope_chargeback
+
+    cb = {
+        "workspaces": [
+            {"name": "team-a", "members": [{"userName": "alice"}, {"userName": "bob"}]},
+            {"name": "team-b", "members": [{"userName": "carol"}]},
+        ],
+        "users": {
+            "licensedUsers": [
+                {"username": "alice"},
+                {"username": "bob"},
+                {"username": "carol"},
+            ]
+        },
+    }
+    scoped = _scope_chargeback(cb, {"team-a"})
+    assert [w["name"] for w in scoped["workspaces"]] == ["team-a"]
+    assert {u["username"] for u in scoped["users"]["licensedUsers"]} == {"alice", "bob"}
+
+
+def test_scope_label_org_vs_scoped():
+    from cometx.cli.admin_growth_report import GrowthReporter
+
+    org = GrowthReporter._scope_label(None, 4, 165, 137, True)
+    assert org.startswith("Org-wide: 165 workspaces, 137 users")
+    assert "4 workspace(s)" in org
+    assert GrowthReporter._scope_label({"a", "b"}, 2, 165, 137, True) == (
+        "Scoped to 2 selected workspace(s)"
+    )
+    assert "accessible to this key: 4" in GrowthReporter._scope_label(
+        None, 4, None, None, False
+    )
+
+
+def test_leaderboards_workspaces_org_wide_from_chargeback():
+    from cometx.cli.admin_growth_report import GrowthReporter
+    from cometx.cli.admin_growth_users import parse_users, parse_workspaces
+
+    # chargeback with EXACT per-workspace experiment/project counts
+    cb = {
+        "workspaces": [
+            {
+                "name": "team-a",
+                "numberOfExperiments": 40,
+                "projects": [{}, {}],
+                "members": [{"userName": "alice"}],
+            },
+            {
+                "name": "team-b",
+                "numberOfExperiments": 90,
+                "projects": [{}],
+                "members": [{"userName": "bob"}],
+            },
+        ],
+        "users": {
+            "licensedUsers": [
+                {
+                    "username": "alice",
+                    "email": "a",
+                    "opikSpanCount": 5000,
+                    "lastUsedAt": 1,
+                },
+                {"username": "bob", "email": "b", "opikSpanCount": 0, "lastUsedAt": 1},
+            ]
+        },
+    }
+    api = MagicMock()
+    r = GrowthReporter(
+        api, window="7d", units="month", platforms="em,opik", leaderboard_top_n=5
+    )
+    section = r._build_leaderboards_section(
+        usage=[],
+        users=parse_users(cb),
+        ran={"em": True, "opik": True, "mpm": False},
+        ws_records=parse_workspaces(cb),
+    )
+    exp_top = next(
+        c for c in section["charts"] if c["id"] == "chart-lb-ws-experiments-top"
+    )
+    # exact per-workspace numberOfExperiments: team-b(90) > team-a(40)
+    assert [row["label"] for row in exp_top["data"]["rows"]] == ["team-b", "team-a"]
+    assert exp_top["data"]["rows"][0]["value"] == 90
+    assert "exact" in exp_top["hint"]
+    # projects leaderboard (exact) + Opik spans (per-user proxy) also present
+    assert any(c["id"] == "chart-lb-ws-projects-top" for c in section["charts"])
+    assert any(c["id"] == "chart-lb-ws-spans-top" for c in section["charts"])
+
+
+def test_unified_section_org_overview_from_chargeback():
+    from cometx.cli.admin_growth_report import GrowthReporter
+    from cometx.cli.admin_growth_users import parse_users, parse_workspaces
+
+    jan = int(
+        datetime.datetime(2026, 1, 15, tzinfo=datetime.timezone.utc).timestamp() * 1000
+    )
+    feb = int(
+        datetime.datetime(2026, 2, 15, tzinfo=datetime.timezone.utc).timestamp() * 1000
+    )
+    now_ms = int(
+        datetime.datetime(2026, 7, 1, tzinfo=datetime.timezone.utc).timestamp() * 1000
+    )
+    cb = {
+        "workspaces": [
+            {
+                "name": "team-a",
+                "numberOfExperiments": 40,
+                "projects": [{}, {}],
+                "members": [{"userName": "alice"}],
+            },
+            {
+                "name": "team-b",
+                "numberOfExperiments": 90,
+                "projects": [{}],
+                "members": [{"userName": "bob"}],
+            },
+        ],
+        "users": {
+            "licensedUsers": [
+                {
+                    "username": "alice",
+                    "email": "a",
+                    "createdAt": jan,
+                    "lastUsedAt": now_ms,
+                },
+                {
+                    "username": "bob",
+                    "email": "b",
+                    "createdAt": feb,
+                    "lastUsedAt": now_ms,
+                },
+            ]
+        },
+    }
+    api = MagicMock()
+    r = GrowthReporter(api, window="7d", units="month", platforms="em,opik")
+    section = r._build_unified_section(
+        [],
+        _win(),
+        0,
+        people_users=parse_users(cb),
+        ws_records=parse_workspaces(cb),
+        now_ms=now_ms,
+        active_window_days=30,
+    )
+    assert section["title"] == "Organization overview (chargeback)"
+    kpi_labels = [k["label"] for k in section["kpis"]]
+    # "Total experiments" was replaced by a workspace-growth KPI (analog of the
+    # Users section's user-growth KPI), labelled "New in <window> (% of base)".
+    assert any(x.startswith("New in") for x in kpi_labels)
+    assert "Total experiments" not in kpi_labels
+    growth = next(k for k in section["kpis"] if k["label"].startswith("New in"))
+    # alice's team-a created in Jan (in-window), bob's team-b in Feb (in-window),
+    # none before the window start -> 0 before -> 0.0%, "+2 new"
+    assert growth["sub"] == "+2 new"
+    ids = [c["id"] for c in section["charts"]]
+    # Chargeback charts stay; SDK creation timelines move to per-product sections.
+    assert "chart-unified-platform-mix" in ids
+    assert "chart-unified-workspaces-created" not in ids
+    assert "chart-unified-projects-cumulative" not in ids
+    # Added-vs-deleted is now a bars+line combo, not a plain line chart.
+    churn = next(
+        c for c in section["charts"] if c["id"] == "chart-unified-workspace-churn"
+    )
+    assert churn["kind"] == "barsLine"
+    assert churn["data"]["bars"] == ["added", "deleted"]
+    assert churn["data"]["line"] == "rate"
+    assert all("rate" in p["values"] for p in churn["data"]["points"])
+    assert section["table"]["title"] == "By workspace (org-wide, chargeback)"
+
+
+def test_leaderboards_omit_traces_board():
+    from cometx.cli.admin_growth_report import GrowthReporter
+    from cometx.cli.admin_growth_users import parse_users, parse_workspaces
+
+    cb = {
+        "workspaces": [
+            {
+                "name": "team-a",
+                "numberOfExperiments": 5,
+                "projects": [{}],
+                "members": [{"userName": "a"}],
+            }
+        ],
+        "users": {"licensedUsers": [{"username": "a", "email": "a", "lastUsedAt": 1}]},
+    }
+    api = MagicMock()
+    r = GrowthReporter(api, window="7d", units="month", platforms="em,opik")
+    section = r._build_leaderboards_section(
+        usage=[],
+        users=parse_users(cb),
+        ran={"em": True, "opik": True, "mpm": False},
+        ws_records=parse_workspaces(cb),
+    )
+    assert not any("traces" in c["id"] for c in section["charts"])
+
+
+def test_short_api_error_condenses_verbose_sdk_error():
+    from cometx.cli.admin_growth_report import _short_api_error
+
+    verbose = (
+        "headers: {'content-security-policy': \"base-uri 'self'\"}, "
+        "status_code: 400, body: {'code': 400, 'message': 'No such workspace!'}"
+    )
+    assert _short_api_error(verbose) == "400: No such workspace!"
+    assert _short_api_error("plain boom") == "plain boom"
+    long = "x" * 300
+    assert len(_short_api_error(long)) <= 160
+
+
+def test_growth_rate_chart_period_over_period():
+    import datetime
+
+    from cometx.cli.admin_growth_report import CreationEvent, GrowthReporter
+
+    api = MagicMock()
+    api.config = {"comet.url_override": "https://c.example.com"}
+
+    def ev(y, m):
+        return CreationEvent(
+            "opik",
+            "w",
+            f"p{y}{m}",
+            "opik_project",
+            datetime.datetime(y, m, 1, tzinfo=datetime.timezone.utc),
+        )
+
+    # new per month: Jan 1, Feb 2, Mar 1 -> cumulative 1,3,4 -> rate 0, 200, 33.3
+    events = [ev(2024, 1), ev(2024, 2), ev(2024, 2), ev(2024, 3)]
+    r = GrowthReporter(api, window="7d", units="month", platforms="opik")
+    c = r._growth_rate_chart(events, "chart-x", "Growth rate")
+    assert c["kind"] == "lines"
+    rates = {p["key"]: p["values"]["rate"] for p in c["data"]["points"]}
+    assert rates == {"2024-01": 0.0, "2024-02": 200.0, "2024-03": 33.3}
+    # single period -> no rate
+    assert r._growth_rate_chart([ev(2024, 1)], "x", "t") is None

--- a/tests/unit/test_admin_growth_report.py
+++ b/tests/unit/test_admin_growth_report.py
@@ -2,6 +2,8 @@ import datetime
 import importlib
 from unittest.mock import MagicMock
 
+import pytest
+
 
 def test_growth_report_delegate_exists():
     m = importlib.import_module("cometx.cli.admin_growth_report")
@@ -1111,6 +1113,42 @@ def test_build_raises_when_chargeback_unavailable(monkeypatch):
         assert False, "expected GrowthReportError"
     except GrowthReportError as exc:
         assert "admin API key" in str(exc)
+
+
+def test_build_reports_malformed_url_as_a_url_problem(monkeypatch):
+    import cometx.cli.admin_growth_report as agr
+    from cometx.cli.admin_growth_report import GrowthReporter, GrowthReportError
+    from cometx.utils import InvalidServerURLError
+
+    def boom(*a, **k):
+        raise InvalidServerURLError("Comet server URL must be an http(s):// URL")
+
+    monkeypatch.setattr(agr, "fetch_chargeback_report", boom)
+    r = GrowthReporter(MagicMock(), window="7d", units="month")
+    with pytest.raises(GrowthReportError) as exc_info:
+        r.build([])
+    assert "could not reach the chargeback endpoint" in str(exc_info.value)
+    assert "admin API key" not in str(exc_info.value)
+
+
+def test_build_reports_non_json_response_as_unavailable_not_bad_url(monkeypatch):
+    # response.json() raises json.JSONDecodeError -- a ValueError subclass --
+    # when the endpoint answers 2xx with an HTML login page. That must NOT be
+    # reported as a malformed URL; it belongs in the unavailable-endpoint path.
+    import json
+
+    import cometx.cli.admin_growth_report as agr
+    from cometx.cli.admin_growth_report import GrowthReporter, GrowthReportError
+
+    def boom(*a, **k):
+        raise json.JSONDecodeError("Expecting value", "<html>", 0)
+
+    monkeypatch.setattr(agr, "fetch_chargeback_report", boom)
+    r = GrowthReporter(MagicMock(), window="7d", units="month")
+    with pytest.raises(GrowthReportError) as exc_info:
+        r.build([])
+    assert "admin API key" in str(exc_info.value)
+    assert "could not reach the chargeback endpoint" not in str(exc_info.value)
 
 
 def test_generate_growth_report_signature_has_no_sdk_kwargs():

--- a/tests/unit/test_admin_growth_report.py
+++ b/tests/unit/test_admin_growth_report.py
@@ -31,89 +31,161 @@ def _win():
 
 
 def _sample_report_data():
-    """A representative `report_data` payload matching the documented C8
-    contract: a top-level `window`, a unified section, and per-product
-    (opik/em/mpm) growth + adoption sections (EM additionally carries a
-    registry-engagement snapshot panel)."""
+    """A representative chargeback-only `report_data` payload: a top-level
+    `window` plus the four chargeback sections (Organization overview, Users,
+    Leaderboards, Personal vs service accounts). No `products`/`collectors` —
+    those belonged to the retired SDK/platform-direct methodology."""
     return {
         "meta": {
             "title": "Growth report — acme <script> & Co",
             "org": "acme-research",
             "generated": "2026-07-09",
-            "source": "Comet Admin API",
+            "source": "Comet Admin API (chargeback)",
+            "scope": "Org-wide: 4 workspaces, 12 users (chargeback)",
         },
         "window": {
             "start": "2026-07-02",
             "end": "2026-07-09",
             "units": "day",
             "label": "Analysis window: Jul 2 – Jul 9, 2026 (7d)",
-            "count_before": 65,
+            "count_before": 0,
         },
-        "collectors": {"opik": True, "em": True, "mpm": False},
         "sections": {
             "unified": {
-                "title": "Workspaces & projects",
+                "title": "Organization overview (chargeback)",
                 "window_chip": "Analysis window: Jul 2 – Jul 9, 2026 (7d)",
                 "kpis": [
-                    {"label": "Workspaces", "value": 4},
-                    {"label": "Projects", "value": 77, "tone": "ok"},
-                    {"label": "New (7d)", "value": "+12"},
+                    {"label": "Total workspaces", "value": 4},
                     {
-                        "label": "Growth (7d)",
+                        "label": "Total projects",
+                        "value": 77,
+                        "sub": "EM projects",
+                        "tone": "ok",
+                    },
+                    {
+                        "label": "New in 7d (% of base)",
                         "value": "18.5%",
-                        "sub": "vs 65 before window",
+                        "sub": "+12 new",
+                    },
+                    {
+                        "label": "Active workspaces %",
+                        "value": "75.0%",
+                        "sub": "3/4 active",
                     },
                 ],
                 "charts": [
                     {
-                        "id": "chart-unified-created",
-                        "kind": "stackedBars",
-                        "title": "Projects created",
-                        "hint": "by kind · monthly",
-                        "legend": [
-                            {"label": "Opik", "color": "--accent"},
-                            {"label": "EM", "color": "--sdk"},
-                            {"label": "MPM", "color": "--ok"},
-                        ],
+                        "id": "chart-unified-platform-mix",
+                        "kind": "groupedBarsH",
+                        "title": "Workspace platform mix",
+                        "hint": "org-wide (chargeback); Opik is a per-user proxy",
                         "data": {
-                            "categories": [
-                                "opik_project",
-                                "em_project",
-                                "mpm_model",
-                            ],
-                            "labels": {
-                                "opik_project": "Opik",
-                                "em_project": "EM",
-                                "mpm_model": "MPM",
-                            },
-                            "colors": ["--accent", "--sdk", "--ok"],
-                            "points": [
-                                {
-                                    "key": "2026-06",
-                                    "values": {
-                                        "opik_project": 3,
-                                        "em_project": 1,
-                                        "mpm_model": 0,
-                                    },
-                                },
-                                {
-                                    "key": "2026-07",
-                                    "values": {
-                                        "opik_project": 2,
-                                        "em_project": 2,
-                                        "mpm_model": 1,
-                                    },
-                                },
-                            ],
-                            "window_start": "2026-07",
-                            "window_end": "2026-07",
+                            "rows": [
+                                {"label": "EM only", "value": 2},
+                                {"label": "Opik only", "value": 1},
+                                {"label": "EM + Opik", "value": 1},
+                                {"label": "Neither", "value": 0},
+                            ]
                         },
                     },
                     {
-                        "id": "chart-unified-by-workspace",
+                        "id": "chart-unified-workspace-churn",
+                        "kind": "barsLine",
+                        "title": "Workspaces added vs. deleted",
+                        "hint": "org-wide (chargeback) · monthly · deletion is a proxy",
+                        "legend": [
+                            {"label": "Added", "color": "--ok"},
+                            {"label": "Deleted", "color": "--warn"},
+                            {"label": "Growth rate", "color": "--accent"},
+                        ],
+                        "data": {
+                            "points": [
+                                {
+                                    "key": "2026-06",
+                                    "values": {"added": 3, "deleted": 0, "rate": 0.0},
+                                },
+                                {
+                                    "key": "2026-07",
+                                    "values": {"added": 1, "deleted": 0, "rate": 33.3},
+                                },
+                            ],
+                            "bars": ["added", "deleted"],
+                            "line": "rate",
+                            "bar_labels": {"added": "Added", "deleted": "Deleted"},
+                            "bar_colors": ["--ok", "--warn"],
+                            "line_label": "Growth rate",
+                            "line_color": "--accent",
+                            "window_start": None,
+                            "window_end": None,
+                        },
+                    },
+                ],
+                "table": {
+                    "title": "By workspace (org-wide, chargeback)",
+                    "headers": [
+                        "Workspace",
+                        "Members",
+                        "Projects",
+                        "Experiments",
+                        "Data (MB)",
+                    ],
+                    "rows": [
+                        ["ws-alpha", 3, 15, 40, 120],
+                        ["ws-beta", 2, 20, 37, 95],
+                    ],
+                },
+            },
+            "people": {
+                "title": "Users",
+                "window_chip": "Analysis window: Jul 2 – Jul 9, 2026 (7d)",
+                "kpis": [
+                    {"label": "Total users", "value": 12},
+                    {"label": "Active users (60d)", "value": 9},
+                    {"label": "Active users %", "value": "75.0%"},
+                    {
+                        "label": "New in 7d (% of base)",
+                        "value": "9.1%",
+                        "sub": "+1 new",
+                    },
+                ],
+                "charts": [
+                    {
+                        "id": "chart-people-active-total",
+                        "kind": "lines",
+                        "title": "Active vs. total users",
+                        "hint": "active window 60d · monthly",
+                        "legend": [
+                            {"label": "Total", "color": "--sdk"},
+                            {"label": "Active", "color": "--ok"},
+                        ],
+                        "data": {
+                            "categories": ["total", "active"],
+                            "labels": {"total": "Total", "active": "Active"},
+                            "colors": ["--sdk", "--ok"],
+                            "points": [
+                                {
+                                    "key": "2026-06",
+                                    "values": {"total": 10, "active": 7},
+                                },
+                                {
+                                    "key": "2026-07",
+                                    "values": {"total": 12, "active": 9},
+                                },
+                            ],
+                            "window_start": None,
+                            "window_end": None,
+                        },
+                    }
+                ],
+            },
+            "leaderboards": {
+                "title": "Leaderboards",
+                "charts": [
+                    {
+                        "id": "chart-lb-ws-experiments-top",
                         "kind": "groupedBarsH",
-                        "title": "Projects by workspace",
-                        "hint": "current totals",
+                        "title": "Top 5 workspaces by experiments",
+                        "hint": "org-wide, exact (chargeback per-workspace)",
                         "data": {
                             "rows": [
                                 {"label": "ws-alpha", "value": 40},
@@ -121,125 +193,37 @@ def _sample_report_data():
                             ]
                         },
                     },
+                    {
+                        "id": "chart-lb-user-opik_span_count-top",
+                        "kind": "groupedBarsH",
+                        "title": "Top 5 users by Opik spans",
+                        "hint": "org-wide (chargeback)",
+                        "data": {
+                            "rows": [
+                                {"label": "alice", "value": 5000},
+                                {"label": "bob", "value": 1200},
+                            ]
+                        },
+                    },
                 ],
-                "table": {
-                    "title": "By workspace",
-                    "headers": ["Workspace", "Opik", "EM", "MPM", "Total"],
-                    "rows": [
-                        ["ws-alpha", 20, 15, 5, 40],
-                        ["ws-beta", 10, 20, 7, 37],
-                    ],
-                },
             },
-            "products": {
-                "opik": {
-                    "label": "Opik",
-                    "growth": {
-                        "title": "Opik — growth",
-                        "window_chip": "Analysis window: Jul 2 – Jul 9, 2026 (7d)",
-                        "kpis": [
-                            {"label": "Workspaces", "value": 2},
-                            {"label": "Total", "value": 30},
-                            {"label": "New (7d)", "value": "+5"},
-                            {
-                                "label": "Growth (7d)",
-                                "value": "20.0%",
-                                "sub": "vs 25 before window",
-                            },
-                        ],
-                        "charts": [
-                            {
-                                "id": "chart-opik-bars",
-                                "kind": "bars",
-                                "title": "New Opik projects",
-                                "hint": "by month",
-                                "data": {
-                                    "points": [
-                                        {"key": "2026-06", "value": 3},
-                                        {"key": "2026-07", "value": 5},
-                                    ],
-                                    "window_start": "2026-07",
-                                    "window_end": "2026-07",
-                                },
-                            },
-                            {
-                                "id": "chart-opik-area",
-                                "kind": "area",
-                                "title": "Opik projects — cumulative",
-                                "hint": "all-time",
-                                "data": {
-                                    "points": [
-                                        {"key": "2026-06", "value": 25},
-                                        {"key": "2026-07", "value": 30},
-                                    ],
-                                    "window_start": "2026-07",
-                                    "window_end": "2026-07",
-                                    "delta": 5,
-                                },
-                            },
-                        ],
-                        "table": {
-                            "headers": ["Workspace", "Opik projects"],
-                            "rows": [["ws-alpha", 20], ["ws-beta", 10]],
+            "personal_vs_service": {
+                "title": "Personal vs. service accounts",
+                "charts": [
+                    {
+                        "id": "chart-personal-vs-service-experiments",
+                        "kind": "groupedBarsH",
+                        "title": "Personal vs. service accounts: experiments",
+                        "hint": "Source: heuristic (regex); admin API returned no "
+                        "service accounts.",
+                        "data": {
+                            "rows": [
+                                {"label": "Personal", "value": 70},
+                                {"label": "Service", "value": 7},
+                            ]
                         },
-                    },
-                    "adoption": {
-                        "title": "Opik — adoption / usage",
-                        "kpis": [{"label": "Span count", "value": 154200}],
-                        "charts": [
-                            {
-                                "id": "chart-opik-spans",
-                                "kind": "bars",
-                                "title": "Span count",
-                                "hint": "by month",
-                                "data": {
-                                    "points": [
-                                        {"key": "2026-06", "value": 70000},
-                                        {"key": "2026-07", "value": 84200},
-                                    ],
-                                    "window_start": "2026-07",
-                                    "window_end": "2026-07",
-                                },
-                            }
-                        ],
-                        "table": {
-                            "title": "Span count by project",
-                            "headers": ["Project", "Span count"],
-                            "rows": [["proj-1", 100000], ["proj-2", 54200]],
-                        },
-                    },
-                },
-                "em": {
-                    "label": "EM",
-                    "growth": {
-                        "title": "EM — growth",
-                        "kpis": [{"label": "Workspaces", "value": 2}],
-                        "charts": [],
-                        "table": None,
-                    },
-                    "adoption": {
-                        "title": "EM — adoption / usage",
-                        "kpis": [{"label": "Experiment count", "value": 900}],
-                        "charts": [],
-                        "panels": [
-                            {
-                                "title": "Model-registry engagement",
-                                "hint": "snapshot, not over-time",
-                                "headers": [
-                                    "Workspace",
-                                    "Registered models",
-                                    "Model versions",
-                                ],
-                                "rows": [
-                                    ["ws-alpha", 2, 3],
-                                    ["ws-beta", 1, 1],
-                                ],
-                            }
-                        ],
-                    },
-                },
-                # mpm intentionally omitted to exercise the "missing section"
-                # robustness path.
+                    }
+                ],
             },
         },
     }
@@ -254,7 +238,7 @@ def test_build_html_is_self_contained_and_secure():
     assert 'id="report-data"' in doc
     assert "http://" not in doc
     assert "https://" not in doc
-    assert "Workspaces & projects" in doc
+    assert "Organization overview (chargeback)" in doc
     assert "<svg" not in doc  # charts are drawn client-side, not server-side
     assert "createElementNS" in doc  # the inline SVG-drawing JS
     assert '"window"' in doc  # the embedded json payload
@@ -335,8 +319,8 @@ def test_build_html_takes_only_report_data_and_ignores_env_secrets(monkeypatch):
 def test_build_html_handles_missing_sections_gracefully():
     from cometx.cli.admin_growth_report import build_html
 
-    # No products at all, and an empty unified section -- must not raise.
-    doc = build_html({"sections": {"unified": {}, "products": {}}})
+    # An empty unified section (and a stray legacy key) -- must not raise.
+    doc = build_html({"sections": {"unified": {}}})
     assert "<style>" in doc
     assert 'id="report-data"' in doc
 
@@ -384,7 +368,7 @@ def test_write_html_writes_file_and_returns_path(tmp_path):
     content = out.read_text(encoding="utf-8")
     assert "<style>" in content
     assert 'id="report-data"' in content
-    assert "Workspaces & projects" in content
+    assert "Organization overview (chargeback)" in content
 
 
 def test_write_growth_html_delegates_to_renderer(tmp_path):
@@ -490,7 +474,7 @@ def test_people_section_built_from_chargeback():
     assert section["title"] == "Users"
     labels = [k["label"] for k in section["kpis"]]
     assert "Active users %" in labels
-    # workspace metrics moved to the Workspaces & projects section
+    # workspace metrics live in the Organization overview section
     assert "Active workspaces %" not in labels
     assert any(x.startswith("Active users (") for x in labels)
 

--- a/tests/unit/test_admin_growth_report.py
+++ b/tests/unit/test_admin_growth_report.py
@@ -1861,3 +1861,142 @@ def test_leaderboards_omit_platform_that_did_not_run():
     section = r._build_leaderboards_section(usage=[], users=[],
         ran={"em": False, "opik": False, "mpm": False})
     assert section is None or not section.get("charts")
+
+
+def test_fetch_service_accounts_parses_name_list():
+    from cometx.cli.admin_growth_report import _fetch_service_accounts
+
+    api = MagicMock()
+    api.config = {"comet.url_override": "https://c.example.com"}
+    api.api_key = "K"
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = {"serviceAccounts": [{"name": "svc-a"}, {"name": "svc-b"}]}
+    api._client.get.return_value = resp
+
+    names = _fetch_service_accounts(api)
+
+    assert names == {"svc-a", "svc-b"}
+    called_url = api._client.get.call_args[0][0]
+    assert called_url == "https://c.example.com/api/admin/service-accounts"
+
+
+def test_fetch_service_accounts_returns_none_on_failure():
+    from cometx.cli.admin_growth_report import _fetch_service_accounts
+
+    api = MagicMock()
+    api.config = {"comet.url_override": "https://c.example.com"}
+    api.api_key = "K"
+    api._client.get.side_effect = RuntimeError("boom")
+
+    assert _fetch_service_accounts(api) is None
+
+
+def test_build_personal_vs_service_section_admin_api_source():
+    from cometx.cli.admin_growth_report import GrowthReporter
+    from cometx.cli.admin_growth_users import parse_users
+
+    api = MagicMock()
+    r = GrowthReporter(api, window="7d", units="month", platforms="em")
+    cb = {"workspaces": [], "users": {"licensedUsers": [
+        {"username": "alice", "email": "a@x", "experimentCount": 40, "dataLoggedMb": 1.0,
+         "opikSpanCount": 5, "lastUsedAt": 1, "suspended": False},
+        {"username": "bob", "email": "b@x", "experimentCount": 1, "dataLoggedMb": 0.0,
+         "opikSpanCount": 0, "lastUsedAt": 1, "suspended": False},
+    ]}}
+    users = parse_users(cb)
+
+    section = r._build_personal_vs_service_section(users, service_account_names={"bob"})
+
+    assert section["title"] == "Personal vs. service accounts"
+    assert "admin API" in section["hint"]
+    exp_chart = next(c for c in section["charts"] if "experiments" in c["title"])
+    rows = {row["label"]: row["value"] for row in exp_chart["data"]["rows"]}
+    assert rows == {"Personal": 40, "Service": 1}
+
+
+def test_build_personal_vs_service_section_heuristic_fallback_omits_empty_metric():
+    from cometx.cli.admin_growth_report import GrowthReporter
+    from cometx.cli.admin_growth_users import parse_users
+
+    api = MagicMock()
+    r = GrowthReporter(api, window="7d", units="month", platforms="em")
+    cb = {"workspaces": [], "users": {"licensedUsers": [
+        {"username": "svc-pipeline", "email": "p@x", "experimentCount": 3, "dataLoggedMb": 0.0,
+         "lastUsedAt": 1},
+        {"username": "dana", "email": "d@x", "experimentCount": 7, "dataLoggedMb": 0.0,
+         "lastUsedAt": 1},
+    ]}}
+    users = parse_users(cb)
+
+    section = r._build_personal_vs_service_section(users, service_account_names=None)
+
+    assert "heuristic" in section["hint"]
+    # No user has opik_span_count set -> spans metric all-zero -> omitted
+    assert all("spans" not in c["title"] for c in section["charts"])
+    exp_chart = next(c for c in section["charts"] if "experiments" in c["title"])
+    rows = {row["label"]: row["value"] for row in exp_chart["data"]["rows"]}
+    assert rows == {"Personal": 7, "Service": 3}
+
+
+def test_build_personal_vs_service_section_none_when_no_users():
+    from cometx.cli.admin_growth_report import GrowthReporter
+
+    api = MagicMock()
+    r = GrowthReporter(api, window="7d", units="month", platforms="em")
+    assert r._build_personal_vs_service_section([], service_account_names=None) is None
+
+
+def test_assemble_report_data_wires_personal_vs_service_section(monkeypatch):
+    """build() end-to-end: chargeback present -> personal_vs_service section
+    appears in report_data["sections"], sourced from the admin API when
+    _fetch_service_accounts succeeds."""
+    from cometx.cli.admin_growth_report import GrowthReporter
+    import cometx.cli.admin_growth_report as agr
+
+    api = MagicMock()
+    api.config = {"comet.url_override": "https://c.example.com"}
+    api.api_key = "K"
+    api.get_workspaces.return_value = []
+    cb = {"workspaces": [], "users": {"licensedUsers": [
+        {"username": "alice", "email": "a@x", "experimentCount": 40, "dataLoggedMb": 1.0,
+         "opikSpanCount": 5, "lastUsedAt": 1, "suspended": False},
+        {"username": "bob", "email": "b@x", "experimentCount": 1, "dataLoggedMb": 0.0,
+         "opikSpanCount": 0, "lastUsedAt": 1, "suspended": False},
+    ]}}
+    monkeypatch.setattr(agr, "fetch_chargeback_report", lambda *a, **k: cb)
+    monkeypatch.setattr(agr, "_fetch_service_accounts", lambda api: {"bob"})
+
+    r = GrowthReporter(api, window="7d", units="month", platforms="em",
+                        active_window="60d", include_users=True, leaderboard_top_n=5)
+    data = r.build([])
+
+    section = data["sections"]["personal_vs_service"]
+    assert "admin API" in section["hint"]
+
+
+def test_assemble_report_data_degrades_personal_vs_service_without_crashing(monkeypatch):
+    """If _fetch_service_accounts (or the section builder) blows up, build()
+    must not crash -- the section is simply omitted."""
+    from cometx.cli.admin_growth_report import GrowthReporter
+    import cometx.cli.admin_growth_report as agr
+
+    api = MagicMock()
+    api.config = {"comet.url_override": "https://c.example.com"}
+    api.api_key = "K"
+    api.get_workspaces.return_value = []
+    cb = {"workspaces": [], "users": {"licensedUsers": [
+        {"username": "alice", "email": "a@x", "experimentCount": 1, "dataLoggedMb": 0.0,
+         "lastUsedAt": 1, "suspended": False},
+    ]}}
+    monkeypatch.setattr(agr, "fetch_chargeback_report", lambda *a, **k: cb)
+
+    def _boom(api):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(agr, "_fetch_service_accounts", _boom)
+
+    r = GrowthReporter(api, window="7d", units="month", platforms="em",
+                        active_window="60d", include_users=True, leaderboard_top_n=5)
+    data = r.build([])  # must not raise
+
+    assert "personal_vs_service" not in data["sections"]

--- a/tests/unit/test_admin_growth_report.py
+++ b/tests/unit/test_admin_growth_report.py
@@ -1870,6 +1870,53 @@ def test_malformed_chargeback_degrades_people_section_without_crashing(monkeypat
     assert "people" not in data["sections"]
 
 
+def test_malformed_chargeback_degrades_leaderboards_and_personal_vs_service(
+    monkeypatch, capsys
+):
+    """Same malformed chargeback as above, but exercising the leaderboards /
+    personal_vs_service wiring: `leaderboard_users` is assigned from
+    `parse_users(chargeback)` inside the leaderboards `try` block, then
+    referenced later (`if leaderboard_users:`) in the personal-vs-service
+    block. Before the fix, a `parse_users` failure left `leaderboard_users`
+    unbound, so the later reference raised `UnboundLocalError` -- masked by
+    the personal-vs-service `except`, but printing a misleading "referenced
+    before assignment" warning that misattributes the failure. `build()`
+    must not raise either way, but after the fix neither the leaderboards
+    nor personal_vs_service sections are present and no misleading
+    UnboundLocalError-style warning is printed."""
+    import cometx.cli.admin_growth_report as agr
+    from cometx.cli.admin_growth_report import GrowthReporter
+
+    api = MagicMock()
+    api.config = {"comet.url_override": "https://c.example.com"}
+    api.api_key = "K"
+    api.get_workspaces.return_value = []
+
+    malformed = {"workspaces": [], "users": {"licensedUsers": ["not-a-dict"]}}
+    monkeypatch.setattr(agr, "fetch_chargeback_report", lambda *a, **k: malformed)
+
+    r = GrowthReporter(
+        api,
+        window="7d",
+        units="month",
+        platforms="em",
+        active_window="60d",
+        include_users=True,
+        leaderboard_top_n=5,
+    )
+
+    data = r.build([])  # must not raise
+
+    assert "people" not in data["sections"]
+    assert "leaderboards" not in data["sections"]
+    assert "personal_vs_service" not in data["sections"]
+
+    captured = capsys.readouterr()
+    assert "referenced before assignment" not in captured.out
+    assert "not associated with a value" not in captured.out
+    assert "leaderboard_users" not in captured.out
+
+
 def test_leaderboards_rank_workspaces_top_n():
     from cometx.cli.admin_growth_report import GrowthReporter, UsageMetric
 
@@ -2005,8 +2052,9 @@ def test_build_personal_vs_service_section_admin_api_source():
     section = r._build_personal_vs_service_section(users, service_account_names={"bob"})
 
     assert section["title"] == "Personal vs. service accounts"
-    assert "admin API" in section["hint"]
+    assert "hint" not in section
     exp_chart = next(c for c in section["charts"] if "experiments" in c["title"])
+    assert "admin API" in exp_chart["hint"]
     rows = {row["label"]: row["value"] for row in exp_chart["data"]["rows"]}
     assert rows == {"Personal": 40, "Service": 1}
 
@@ -2042,10 +2090,11 @@ def test_build_personal_vs_service_section_heuristic_fallback_omits_empty_metric
 
     section = r._build_personal_vs_service_section(users, service_account_names=None)
 
-    assert "heuristic" in section["hint"]
+    assert "hint" not in section
     # No user has opik_span_count set -> spans metric all-zero -> omitted
     assert all("spans" not in c["title"] for c in section["charts"])
     exp_chart = next(c for c in section["charts"] if "experiments" in c["title"])
+    assert "heuristic" in exp_chart["hint"]
     rows = {row["label"]: row["value"] for row in exp_chart["data"]["rows"]}
     assert rows == {"Personal": 7, "Service": 3}
 
@@ -2109,7 +2158,8 @@ def test_assemble_report_data_wires_personal_vs_service_section(monkeypatch):
     data = r.build([])
 
     section = data["sections"]["personal_vs_service"]
-    assert "admin API" in section["hint"]
+    assert "hint" not in section
+    assert all("admin API" in c["hint"] for c in section["charts"])
 
 
 def test_assemble_report_data_degrades_personal_vs_service_without_crashing(

--- a/tests/unit/test_admin_growth_report.py
+++ b/tests/unit/test_admin_growth_report.py
@@ -505,6 +505,7 @@ def test_collect_opik_skips_bad_workspace_and_continues(
 @requires_opik
 def test_collect_opik_emits_trace_count_alongside_spans():
     import datetime
+
     from cometx.cli.admin_growth_report import GrowthReporter
 
     api = MagicMock()
@@ -516,8 +517,10 @@ def test_collect_opik_emits_trace_count_alongside_spans():
     proj.created_at = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
 
     def _metrics(project_id, metric_type, interval, interval_start, interval_end):
-        dp = MagicMock(time=datetime.datetime(2026, 6, 2, tzinfo=datetime.timezone.utc),
-                       value=(10 if metric_type == "SPAN_COUNT" else 3))
+        dp = MagicMock(
+            time=datetime.datetime(2026, 6, 2, tzinfo=datetime.timezone.utc),
+            value=(10 if metric_type == "SPAN_COUNT" else 3),
+        )
         result = MagicMock(data=[dp])
         return MagicMock(results=[result])
 
@@ -526,8 +529,9 @@ def test_collect_opik_emits_trace_count_alongside_spans():
     client.rest_client.projects.find_projects.return_value = page
     client.rest_client.projects.get_project_metrics.side_effect = _metrics
 
-    with patch("opik.Opik", return_value=client), \
-         patch("cometx.cli.smoke_test.get_opik_config", return_value="https://c.example.com"):
+    with patch("opik.Opik", return_value=client), patch(
+        "cometx.cli.smoke_test.get_opik_config", return_value="https://c.example.com"
+    ):
         r = GrowthReporter(api, window="7d", units="month", platforms="opik")
         events, usage = r._collect_opik(["wsA"])
 
@@ -542,25 +546,33 @@ def test_collect_opik_emits_trace_count_alongside_spans():
 @requires_opik
 def test_collect_opik_trace_failure_keeps_spans():
     import datetime
+
     from cometx.cli.admin_growth_report import GrowthReporter
 
     api = MagicMock()
     api.config = {"comet.api_key": "K", "comet.url_override": "https://c.example.com"}
-    proj = MagicMock(); proj.name = "p"; proj.id = "id"
+    proj = MagicMock()
+    proj.name = "p"
+    proj.id = "id"
     proj.created_at = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
 
     def _metrics(project_id, metric_type, interval, interval_start, interval_end):
         if metric_type == "TRACE_COUNT":
             raise RuntimeError("traces boom")
-        dp = MagicMock(time=datetime.datetime(2026, 6, 2, tzinfo=datetime.timezone.utc), value=5)
+        dp = MagicMock(
+            time=datetime.datetime(2026, 6, 2, tzinfo=datetime.timezone.utc), value=5
+        )
         return MagicMock(results=[MagicMock(data=[dp])])
 
     client = MagicMock()
-    client.rest_client.projects.find_projects.return_value = MagicMock(content=[proj], total=1)
+    client.rest_client.projects.find_projects.return_value = MagicMock(
+        content=[proj], total=1
+    )
     client.rest_client.projects.get_project_metrics.side_effect = _metrics
 
-    with patch("opik.Opik", return_value=client), \
-         patch("cometx.cli.smoke_test.get_opik_config", return_value="https://c.example.com"):
+    with patch("opik.Opik", return_value=client), patch(
+        "cometx.cli.smoke_test.get_opik_config", return_value="https://c.example.com"
+    ):
         r = GrowthReporter(api, window="7d", units="month", platforms="opik")
         events, usage = r._collect_opik(["wsA"])
 
@@ -1767,18 +1779,37 @@ def test_generate_growth_report_full_chain_all_platforms(monkeypatch, tmp_path):
 
 
 def test_people_section_built_from_chargeback():
-    import datetime
     from cometx.cli.admin_growth_report import GrowthReporter
 
     api = MagicMock()
     api.config = {"comet.url_override": "https://c.example.com"}
     api.api_key = "K"
-    cb = {"workspaces": [], "users": {"licensedUsers": [
-        {"username": "alice", "email": "a@x", "lastUsedAt": 4_000, "createdAt": 1,
-         "experimentCount": 5, "dataLoggedMb": 1.0, "opikSpanCount": 9, "suspended": False},
-    ]}}
-    r = GrowthReporter(api, window="7d", units="month", platforms="em",
-                       active_window="60d", include_users=True, leaderboard_top_n=5)
+    cb = {
+        "workspaces": [],
+        "users": {
+            "licensedUsers": [
+                {
+                    "username": "alice",
+                    "email": "a@x",
+                    "lastUsedAt": 4_000,
+                    "createdAt": 1,
+                    "experimentCount": 5,
+                    "dataLoggedMb": 1.0,
+                    "opikSpanCount": 9,
+                    "suspended": False,
+                },
+            ]
+        },
+    }
+    r = GrowthReporter(
+        api,
+        window="7d",
+        units="month",
+        platforms="em",
+        active_window="60d",
+        include_users=True,
+        leaderboard_top_n=5,
+    )
     section = r._build_people_section(cb, now_ms=4_500)
     assert section["title"].startswith("Users")
     labels = [k["label"] for k in section["kpis"]]
@@ -1788,11 +1819,14 @@ def test_people_section_built_from_chargeback():
 
 def test_include_users_false_skips_people(monkeypatch):
     from cometx.cli.admin_growth_report import GrowthReporter
+
     api = MagicMock()
-    r = GrowthReporter(api, window="7d", units="month", platforms="em",
-                       include_users=False)
+    r = GrowthReporter(
+        api, window="7d", units="month", platforms="em", include_users=False
+    )
     # build() must not call fetch_chargeback_report when include_users is False
     import cometx.cli.admin_growth_report as agr
+
     called = {"n": 0}
     monkeypatch.setattr(
         agr,
@@ -1808,8 +1842,8 @@ def test_include_users_false_skips_people(monkeypatch):
 def test_malformed_chargeback_degrades_people_section_without_crashing(monkeypatch):
     """A chargeback fetch that succeeds but returns a shape parse_users()
     cannot handle must degrade to no people section, not crash build()."""
-    from cometx.cli.admin_growth_report import GrowthReporter
     import cometx.cli.admin_growth_report as agr
+    from cometx.cli.admin_growth_report import GrowthReporter
 
     api = MagicMock()
     api.config = {"comet.url_override": "https://c.example.com"}
@@ -1838,28 +1872,38 @@ def test_malformed_chargeback_degrades_people_section_without_crashing(monkeypat
 
 def test_leaderboards_rank_workspaces_top_n():
     from cometx.cli.admin_growth_report import GrowthReporter, UsageMetric
+
     api = MagicMock()
-    r = GrowthReporter(api, window="7d", units="month", platforms="em", leaderboard_top_n=2)
+    r = GrowthReporter(
+        api, window="7d", units="month", platforms="em", leaderboard_top_n=2
+    )
     usage = [
         UsageMetric("em", "wsA", "EXPERIMENT_COUNT", 100, project=None, series=[]),
         UsageMetric("em", "wsB", "EXPERIMENT_COUNT", 50, project=None, series=[]),
         UsageMetric("em", "wsC", "EXPERIMENT_COUNT", 10, project=None, series=[]),
     ]
     section = r._build_leaderboards_section(
-        usage=usage, users=[], ran={"em": True, "opik": False, "mpm": False})
+        usage=usage, users=[], ran={"em": True, "opik": False, "mpm": False}
+    )
     charts = section["charts"]
     # a workspace-by-experiments groupedBarsH exists, top-2 only
-    exp_chart = next(c for c in charts if "experiment" in c["title"].lower() and "top" in c["title"].lower())
+    exp_chart = next(
+        c
+        for c in charts
+        if "experiment" in c["title"].lower() and "top" in c["title"].lower()
+    )
     rows = exp_chart["data"]["rows"]
     assert [row["label"] for row in rows] == ["wsA", "wsB"]
 
 
 def test_leaderboards_omit_platform_that_did_not_run():
     from cometx.cli.admin_growth_report import GrowthReporter
+
     api = MagicMock()
     r = GrowthReporter(api, window="7d", units="month", platforms="em")
-    section = r._build_leaderboards_section(usage=[], users=[],
-        ran={"em": False, "opik": False, "mpm": False})
+    section = r._build_leaderboards_section(
+        usage=[], users=[], ran={"em": False, "opik": False, "mpm": False}
+    )
     assert section is None or not section.get("charts")
 
 
@@ -1931,12 +1975,31 @@ def test_build_personal_vs_service_section_admin_api_source():
 
     api = MagicMock()
     r = GrowthReporter(api, window="7d", units="month", platforms="em")
-    cb = {"workspaces": [], "users": {"licensedUsers": [
-        {"username": "alice", "email": "a@x", "experimentCount": 40, "dataLoggedMb": 1.0,
-         "opikSpanCount": 5, "lastUsedAt": 1, "suspended": False},
-        {"username": "bob", "email": "b@x", "experimentCount": 1, "dataLoggedMb": 0.0,
-         "opikSpanCount": 0, "lastUsedAt": 1, "suspended": False},
-    ]}}
+    cb = {
+        "workspaces": [],
+        "users": {
+            "licensedUsers": [
+                {
+                    "username": "alice",
+                    "email": "a@x",
+                    "experimentCount": 40,
+                    "dataLoggedMb": 1.0,
+                    "opikSpanCount": 5,
+                    "lastUsedAt": 1,
+                    "suspended": False,
+                },
+                {
+                    "username": "bob",
+                    "email": "b@x",
+                    "experimentCount": 1,
+                    "dataLoggedMb": 0.0,
+                    "opikSpanCount": 0,
+                    "lastUsedAt": 1,
+                    "suspended": False,
+                },
+            ]
+        },
+    }
     users = parse_users(cb)
 
     section = r._build_personal_vs_service_section(users, service_account_names={"bob"})
@@ -1954,12 +2017,27 @@ def test_build_personal_vs_service_section_heuristic_fallback_omits_empty_metric
 
     api = MagicMock()
     r = GrowthReporter(api, window="7d", units="month", platforms="em")
-    cb = {"workspaces": [], "users": {"licensedUsers": [
-        {"username": "svc-pipeline", "email": "p@x", "experimentCount": 3, "dataLoggedMb": 0.0,
-         "lastUsedAt": 1},
-        {"username": "dana", "email": "d@x", "experimentCount": 7, "dataLoggedMb": 0.0,
-         "lastUsedAt": 1},
-    ]}}
+    cb = {
+        "workspaces": [],
+        "users": {
+            "licensedUsers": [
+                {
+                    "username": "svc-pipeline",
+                    "email": "p@x",
+                    "experimentCount": 3,
+                    "dataLoggedMb": 0.0,
+                    "lastUsedAt": 1,
+                },
+                {
+                    "username": "dana",
+                    "email": "d@x",
+                    "experimentCount": 7,
+                    "dataLoggedMb": 0.0,
+                    "lastUsedAt": 1,
+                },
+            ]
+        },
+    }
     users = parse_users(cb)
 
     section = r._build_personal_vs_service_section(users, service_account_names=None)
@@ -1984,44 +2062,83 @@ def test_assemble_report_data_wires_personal_vs_service_section(monkeypatch):
     """build() end-to-end: chargeback present -> personal_vs_service section
     appears in report_data["sections"], sourced from the admin API when
     _fetch_service_accounts succeeds."""
-    from cometx.cli.admin_growth_report import GrowthReporter
     import cometx.cli.admin_growth_report as agr
+    from cometx.cli.admin_growth_report import GrowthReporter
 
     api = MagicMock()
     api.config = {"comet.url_override": "https://c.example.com"}
     api.api_key = "K"
     api.get_workspaces.return_value = []
-    cb = {"workspaces": [], "users": {"licensedUsers": [
-        {"username": "alice", "email": "a@x", "experimentCount": 40, "dataLoggedMb": 1.0,
-         "opikSpanCount": 5, "lastUsedAt": 1, "suspended": False},
-        {"username": "bob", "email": "b@x", "experimentCount": 1, "dataLoggedMb": 0.0,
-         "opikSpanCount": 0, "lastUsedAt": 1, "suspended": False},
-    ]}}
+    cb = {
+        "workspaces": [],
+        "users": {
+            "licensedUsers": [
+                {
+                    "username": "alice",
+                    "email": "a@x",
+                    "experimentCount": 40,
+                    "dataLoggedMb": 1.0,
+                    "opikSpanCount": 5,
+                    "lastUsedAt": 1,
+                    "suspended": False,
+                },
+                {
+                    "username": "bob",
+                    "email": "b@x",
+                    "experimentCount": 1,
+                    "dataLoggedMb": 0.0,
+                    "opikSpanCount": 0,
+                    "lastUsedAt": 1,
+                    "suspended": False,
+                },
+            ]
+        },
+    }
     monkeypatch.setattr(agr, "fetch_chargeback_report", lambda *a, **k: cb)
     monkeypatch.setattr(agr, "_fetch_service_accounts", lambda api: {"bob"})
 
-    r = GrowthReporter(api, window="7d", units="month", platforms="em",
-                        active_window="60d", include_users=True, leaderboard_top_n=5)
+    r = GrowthReporter(
+        api,
+        window="7d",
+        units="month",
+        platforms="em",
+        active_window="60d",
+        include_users=True,
+        leaderboard_top_n=5,
+    )
     data = r.build([])
 
     section = data["sections"]["personal_vs_service"]
     assert "admin API" in section["hint"]
 
 
-def test_assemble_report_data_degrades_personal_vs_service_without_crashing(monkeypatch):
+def test_assemble_report_data_degrades_personal_vs_service_without_crashing(
+    monkeypatch,
+):
     """If _fetch_service_accounts (or the section builder) blows up, build()
     must not crash -- the section is simply omitted."""
-    from cometx.cli.admin_growth_report import GrowthReporter
     import cometx.cli.admin_growth_report as agr
+    from cometx.cli.admin_growth_report import GrowthReporter
 
     api = MagicMock()
     api.config = {"comet.url_override": "https://c.example.com"}
     api.api_key = "K"
     api.get_workspaces.return_value = []
-    cb = {"workspaces": [], "users": {"licensedUsers": [
-        {"username": "alice", "email": "a@x", "experimentCount": 1, "dataLoggedMb": 0.0,
-         "lastUsedAt": 1, "suspended": False},
-    ]}}
+    cb = {
+        "workspaces": [],
+        "users": {
+            "licensedUsers": [
+                {
+                    "username": "alice",
+                    "email": "a@x",
+                    "experimentCount": 1,
+                    "dataLoggedMb": 0.0,
+                    "lastUsedAt": 1,
+                    "suspended": False,
+                },
+            ]
+        },
+    }
     monkeypatch.setattr(agr, "fetch_chargeback_report", lambda *a, **k: cb)
 
     def _boom(api):
@@ -2029,8 +2146,15 @@ def test_assemble_report_data_degrades_personal_vs_service_without_crashing(monk
 
     monkeypatch.setattr(agr, "_fetch_service_accounts", _boom)
 
-    r = GrowthReporter(api, window="7d", units="month", platforms="em",
-                        active_window="60d", include_users=True, leaderboard_top_n=5)
+    r = GrowthReporter(
+        api,
+        window="7d",
+        units="month",
+        platforms="em",
+        active_window="60d",
+        include_users=True,
+        leaderboard_top_n=5,
+    )
     data = r.build([])  # must not raise
 
     assert "personal_vs_service" not in data["sections"]
@@ -2038,16 +2162,30 @@ def test_assemble_report_data_degrades_personal_vs_service_without_crashing(monk
 
 def test_exclude_personal_filters_by_pattern():
     from cometx.cli.admin_growth_report import GrowthReporter
+
     api = MagicMock()
-    r = GrowthReporter(api, window="7d", units="month", platforms="em",
-                       exclude_personal=True, personal_pattern=r"^user-")
+    r = GrowthReporter(
+        api,
+        window="7d",
+        units="month",
+        platforms="em",
+        exclude_personal=True,
+        personal_pattern=r"^user-",
+    )
     kept = r._filter_personal(["team-a", "user-alice", "team-b"])
     assert kept == ["team-a", "team-b"]
 
 
 def test_exclude_personal_without_pattern_is_noop():
     from cometx.cli.admin_growth_report import GrowthReporter
+
     api = MagicMock()
-    r = GrowthReporter(api, window="7d", units="month", platforms="em",
-                       exclude_personal=True, personal_pattern=None)
+    r = GrowthReporter(
+        api,
+        window="7d",
+        units="month",
+        platforms="em",
+        exclude_personal=True,
+        personal_pattern=None,
+    )
     assert r._filter_personal(["a", "b"]) == ["a", "b"]

--- a/tests/unit/test_admin_growth_report.py
+++ b/tests/unit/test_admin_growth_report.py
@@ -1,40 +1,6 @@
 import datetime
 import importlib
-import importlib.util
-from unittest.mock import MagicMock, patch
-
-import pytest
-
-# opik and comet_mpm are OPTIONAL extras (cometx[all]); CI installs neither by
-# default (opik happens to be in requirements.txt, comet_mpm is not). Tests that
-# patch those SDKs must be skipped when the extra isn't importable, otherwise
-# `@patch("comet_mpm.API")` errors at setup with ModuleNotFoundError.
-requires_opik = pytest.mark.skipif(
-    importlib.util.find_spec("opik") is None,
-    reason="opik extra not installed (cometx[all])",
-)
-requires_mpm = pytest.mark.skipif(
-    importlib.util.find_spec("comet_mpm") is None,
-    reason="comet_mpm extra not installed (cometx[all])",
-)
-
-
-def test_creation_event_and_window():
-    from cometx.cli.admin_growth_report import CreationEvent, Window
-
-    ev = CreationEvent(
-        "opik",
-        "wsA",
-        "proj-1",
-        "project",
-        datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc),
-    )
-    assert ev.kind == "project" and ev.workspace == "wsA"
-    w = Window(
-        datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc),
-        datetime.datetime(2026, 7, 1, tzinfo=datetime.timezone.utc),
-    )
-    assert w.units == "month"
+from unittest.mock import MagicMock
 
 
 def test_growth_report_delegate_exists():
@@ -54,18 +20,6 @@ def test_growth_report_action_registered_in_admin():
     assert "growth-report" in admin_src
 
 
-def _ev(y, m, d, ws="w", uc="p"):
-    from cometx.cli.admin_growth_report import CreationEvent
-
-    return CreationEvent(
-        "opik",
-        ws,
-        uc,
-        "project",
-        datetime.datetime(y, m, d, tzinfo=datetime.timezone.utc),
-    )
-
-
 def _win():
     from cometx.cli.admin_growth_report import Window
 
@@ -74,917 +28,6 @@ def _win():
         datetime.datetime(2026, 12, 31, tzinfo=datetime.timezone.utc),
         "month",
     )
-
-
-def test_continuous_zero_fill():
-    from cometx.cli.admin_growth_report import continuous_series
-
-    counts = {"2026-01": 2, "2026-03": 1}
-    series = continuous_series(counts, "month")
-    keys = [k for k, _ in series]
-    assert keys == ["2026-01", "2026-02", "2026-03"]  # Feb zero-filled
-    assert dict(series)["2026-02"] == 0
-
-
-def test_cumulative_and_growth():
-    from cometx.cli.admin_growth_report import cumulative, growth_stats
-
-    cum = cumulative([("2026-01", 2), ("2026-02", 0), ("2026-03", 1)])
-    assert [v for _, v in cum] == [2, 2, 3]
-    # 2 before window, 3 inside -> pct = 3/2*100 = 150
-    evs = [
-        _ev(2025, 12, 1),
-        _ev(2025, 12, 2),
-        _ev(2026, 2, 1),
-        _ev(2026, 2, 2),
-        _ev(2026, 3, 1),
-    ]
-    g = growth_stats(evs, _win(), "month")
-    assert g["new_in_window"] == 3 and g["total"] == 5 and round(g["pct_growth"]) == 150
-
-
-def _make_em_api():
-    """MagicMock api mimicking verified EM endpoints (see task-C4-context.md)."""
-    api = MagicMock()
-    api._client.get_from_endpoint.return_value = {
-        "projects": [
-            {
-                "projectId": "p1",
-                "projectName": "proj1",
-                "ownerUserName": "someone",
-                "projectDescription": "",
-                "workspaceName": "ws1",
-                "numberOfExperiments": 2,
-                "lastUpdated": 1700000000000,
-                "public": False,
-            },
-            {
-                "projectId": "p2",
-                "projectName": "proj2",
-                "ownerUserName": "someone",
-                "projectDescription": "",
-                "workspaceName": "ws1",
-                "numberOfExperiments": 0,
-                "lastUpdated": 1650000000000,
-                "public": False,
-            },
-        ]
-    }
-
-    def get_experiments(ws, proj):
-        if proj == "proj1":
-            return [
-                MagicMock(start_server_timestamp=1695000000000),
-                MagicMock(start_server_timestamp=1690000000000),
-            ]
-        return []
-
-    api.get_experiments.side_effect = get_experiments
-    api.get_registry_model_names.return_value = ["modelA", "modelB"]
-
-    def get_registry_model_versions(ws, name):
-        return {"modelA": ["1.0.0", "1.0.1"], "modelB": ["1.0.0"]}[name]
-
-    api.get_registry_model_versions.side_effect = get_registry_model_versions
-    return api
-
-
-def test_collect_em_creation_events_use_experiment_proxy():
-    from cometx.cli.admin_growth_report import GrowthReporter
-
-    api = _make_em_api()
-    reporter = GrowthReporter(api, window="7d", units="month", platforms="em")
-    events, _usage = reporter._collect_em(["ws1"])
-
-    assert len(events) == 2
-    assert all(e.kind == "em_project" for e in events)
-    assert all(e.platform == "em" for e in events)
-    assert all(e.workspace == "ws1" for e in events)
-    assert not any(e.kind == "registry_model" for e in events)
-
-    # Experiments must be fetched exactly ONCE per project (not once per
-    # helper) — the list is fetched in _collect_em and shared between the
-    # creation-proxy and the over-time series. 2 projects -> 2 calls.
-    assert api.get_experiments.call_count == 2
-
-    by_proj = {e.use_case: e for e in events}
-    # proj1: earliest experiment start_server_timestamp used as creation proxy
-    assert by_proj["proj1"].created == datetime.datetime.fromtimestamp(
-        1690000000000 / 1000, tz=datetime.timezone.utc
-    )
-    # proj2: no experiments -> falls back to lastUpdated
-    assert by_proj["proj2"].created == datetime.datetime.fromtimestamp(
-        1650000000000 / 1000, tz=datetime.timezone.utc
-    )
-
-
-def test_collect_em_usage_metrics_experiment_count_and_registry_snapshot():
-    from cometx.cli.admin_growth_report import GrowthReporter
-
-    api = _make_em_api()
-    reporter = GrowthReporter(api, window="7d", units="month", platforms="em")
-    _events, usage = reporter._collect_em(["ws1"])
-
-    exp_metrics = [m for m in usage if m.metric == "EXPERIMENT_COUNT"]
-
-    proj1_metric = next(m for m in exp_metrics if m.project == "proj1")
-    assert proj1_metric.value == 2
-    assert proj1_metric.platform == "em" and proj1_metric.workspace == "ws1"
-    assert proj1_metric.series  # non-empty over-time series
-
-    proj2_metric = next(m for m in exp_metrics if m.project == "proj2")
-    assert proj2_metric.value == 0
-
-    ws_total_metric = next(m for m in exp_metrics if m.project is None)
-    assert ws_total_metric.value == 2
-    assert ws_total_metric.workspace == "ws1"
-
-    reg_models = next(m for m in usage if m.metric == "REGISTRY_MODELS")
-    assert reg_models.value == 2
-    assert reg_models.series is None
-    assert reg_models.workspace == "ws1" and reg_models.platform == "em"
-
-    reg_versions = next(m for m in usage if m.metric == "REGISTRY_VERSIONS")
-    assert reg_versions.value == 3
-    assert reg_versions.series is None
-
-    # registry metrics are never CreationEvents / never a use case
-    assert not any(m.metric.startswith("REGISTRY") and m.series for m in usage)
-
-
-def test_collect_em_kpi_total_matches_chart_sum_when_metadata_disagrees():
-    # Regression: the EXPERIMENT_COUNT total must come from the SAME bucketed
-    # timestamps that feed the chart series, NOT from `numberOfExperiments`.
-    # Here the metadata (10) disagrees with the experiments that actually carry
-    # a start_server_timestamp (3), so the old fallback would have produced a
-    # KPI total that didn't equal the cumulative chart sum.
-    from cometx.cli.admin_growth_report import GrowthReporter
-
-    api = MagicMock()
-    api._client.get_from_endpoint.return_value = {
-        "projects": [
-            {
-                "projectName": "proj1",
-                "projectId": "p1",
-                "workspaceName": "ws1",
-                "numberOfExperiments": 10,  # metadata, intentionally != 3
-                "lastUpdated": 1700000000000,
-            }
-        ]
-    }
-    api.get_experiments.return_value = [
-        MagicMock(start_server_timestamp=1695000000000),
-        MagicMock(start_server_timestamp=1695100000000),
-        MagicMock(start_server_timestamp=1695200000000),
-    ]
-    api.get_registry_model_names.return_value = []
-    reporter = GrowthReporter(api, window="7d", units="month", platforms="em")
-    _events, usage = reporter._collect_em(["ws1"])
-
-    proj_metric = next(
-        m for m in usage if m.metric == "EXPERIMENT_COUNT" and m.project == "proj1"
-    )
-    ws_total = next(
-        m for m in usage if m.metric == "EXPERIMENT_COUNT" and m.project is None
-    )
-    # total is derived from counts (3), NOT numberOfExperiments (10)
-    assert proj_metric.value == 3
-    assert ws_total.value == 3
-    # the KPI total equals the cumulative chart sum for the workspace
-    assert ws_total.value == sum(v for _k, v in ws_total.series)
-
-
-def test_collect_em_respects_limit_on_workspaces():
-    from cometx.cli.admin_growth_report import GrowthReporter
-
-    api = _make_em_api()
-    reporter = GrowthReporter(api, window="7d", units="month", platforms="em", limit=1)
-    events, usage = reporter._collect_em(["ws1", "ws2"])
-
-    assert all(e.workspace == "ws1" for e in events)
-    assert all(m.workspace == "ws1" for m in usage)
-    # only one workspace's projects endpoint should have been queried
-    assert api._client.get_from_endpoint.call_count == 1
-
-
-def test_collect_em_skips_bad_project_and_continues(capsys):
-    from cometx.cli.admin_growth_report import GrowthReporter
-
-    api = _make_em_api()
-
-    def get_experiments(ws, proj):
-        if proj == "proj1":
-            raise RuntimeError("boom")
-        return []
-
-    api.get_experiments.side_effect = get_experiments
-    reporter = GrowthReporter(api, window="7d", units="month", platforms="em")
-    events, usage = reporter._collect_em(["ws1"])
-
-    # proj1 blew up but proj2 (and registry metrics) still collected
-    assert any(e.use_case == "proj2" for e in events)
-    assert not any(e.use_case == "proj1" for e in events)
-    assert any(m.metric == "REGISTRY_MODELS" for m in usage)
-
-
-def test_collect_em_filters_projects_not_belonging_to_workspace(capsys):
-    # The EM `projects` endpoint returns a fallback set from another workspace
-    # when the key isn't a member of the requested one, ignoring workspaceName.
-    # Those foreign projects must NOT be attributed to the requested workspace;
-    # the workspace is still reported at 0, and a warning is printed.
-    from cometx.cli.admin_growth_report import GrowthReporter
-
-    api = MagicMock()
-    api._client.get_from_endpoint.return_value = {
-        "projects": [
-            {
-                "projectName": "foreign-proj",
-                "projectId": "x1",
-                "workspaceName": "team-comet-ml",  # != requested workspace
-                "numberOfExperiments": 5,
-                "lastUpdated": 1700000000000,
-            }
-        ]
-    }
-    api.get_registry_model_names.return_value = []
-    api.get_registry_model_versions.return_value = []
-    reporter = GrowthReporter(api, window="7d", units="month", platforms="em")
-    events, usage = reporter._collect_em(["opik-demos"])
-
-    # foreign project is not attributed to opik-demos
-    assert events == []
-    assert not any(m.project == "foreign-proj" for m in usage)
-    # experiments are never fetched for a filtered-out project
-    api.get_experiments.assert_not_called()
-    # workspace is still listed, at an experiment total of 0
-    ws_totals = [
-        m for m in usage if m.metric == "EXPERIMENT_COUNT" and m.project is None
-    ]
-    assert len(ws_totals) == 1
-    assert ws_totals[0].workspace == "opik-demos" and ws_totals[0].value == 0
-    # and a warning was surfaced
-    assert "not belonging to workspace opik-demos" in capsys.readouterr().out
-
-
-def _make_opik_api():
-    """MagicMock api with a REAL dict `.config` (see task-C5-context.md) so
-    host/api_key resolution works without touching MagicMock magic."""
-    api = MagicMock()
-    api.config = {
-        "comet.api_key": "KEY",
-        "comet.url_override": "https://example.com/",
-    }
-    return api
-
-
-def _make_opik_project(id_, name, created_at):
-    project = MagicMock()
-    project.id = id_
-    project.name = name
-    project.created_at = created_at
-    return project
-
-
-def _make_opik_metrics_response(datapoints):
-    """datapoints: list of (time, value) -> a fake get_project_metrics resp."""
-    result = MagicMock()
-    result.data = [MagicMock(time=t, value=v) for t, v in datapoints]
-    resp = MagicMock()
-    resp.results = [result]
-    return resp
-
-
-@patch(
-    "cometx.cli.smoke_test.get_opik_config",
-    return_value="https://example.com/opik/api/",
-)
-@requires_opik
-@patch("opik.Opik")
-def test_collect_opik_creation_events_and_span_count_usage(mock_opik_ctor, _mock_host):
-    from cometx.cli.admin_growth_report import GrowthReporter
-
-    created1 = datetime.datetime(2026, 1, 5, tzinfo=datetime.timezone.utc)
-    created2 = datetime.datetime(2026, 2, 10, tzinfo=datetime.timezone.utc)
-    proj1 = _make_opik_project("id1", "proj1", created1)
-    proj2 = _make_opik_project("id2", "proj2", created2)
-
-    fake_page = MagicMock()
-    fake_page.content = [proj1, proj2]
-    fake_page.total = 2
-
-    mock_client = MagicMock()
-    mock_client.rest_client.projects.find_projects.return_value = fake_page
-
-    def get_project_metrics(project_id, **kwargs):
-        if project_id == "id1":
-            return _make_opik_metrics_response(
-                [
-                    (datetime.datetime(2026, 1, 10, tzinfo=datetime.timezone.utc), 5),
-                    (datetime.datetime(2026, 1, 20, tzinfo=datetime.timezone.utc), 3),
-                ]
-            )
-        return _make_opik_metrics_response(
-            [(datetime.datetime(2026, 2, 15, tzinfo=datetime.timezone.utc), 7)]
-        )
-
-    mock_client.rest_client.projects.get_project_metrics.side_effect = (
-        get_project_metrics
-    )
-    mock_opik_ctor.return_value = mock_client
-
-    api = _make_opik_api()
-    reporter = GrowthReporter(api, window="7d", units="month", platforms="opik")
-    events, usage = reporter._collect_opik(["ws1"])
-
-    # one opik_project CreationEvent per project, created == created_at
-    assert len(events) == 2
-    assert all(e.kind == "opik_project" for e in events)
-    assert all(e.platform == "opik" for e in events)
-    assert all(e.workspace == "ws1" for e in events)
-    by_uc = {e.use_case: e for e in events}
-    assert by_uc["proj1"].created == created1
-    assert by_uc["proj2"].created == created2
-
-    # opik.Opik constructed with resolved host/api_key for the workspace
-    mock_opik_ctor.assert_any_call(
-        workspace="ws1", api_key="KEY", host="https://example.com/opik/api/"
-    )
-
-    span_metrics = [m for m in usage if m.metric == "SPAN_COUNT"]
-
-    proj1_metric = next(m for m in span_metrics if m.project == "proj1")
-    assert proj1_metric.platform == "opik" and proj1_metric.workspace == "ws1"
-    assert proj1_metric.value == 8  # sum of proj1 datapoints
-    assert proj1_metric.series  # non-empty over-time series
-
-    proj2_metric = next(m for m in span_metrics if m.project == "proj2")
-    assert proj2_metric.value == 7
-
-    ws_total_metric = next(m for m in span_metrics if m.project is None)
-    assert ws_total_metric.value == 15  # 8 + 7
-    assert ws_total_metric.workspace == "ws1"
-    assert ws_total_metric.series
-
-
-@patch(
-    "cometx.cli.smoke_test.get_opik_config",
-    return_value="https://example.com/opik/api/",
-)
-@requires_opik
-@patch("opik.Opik")
-def test_collect_opik_respects_limit_on_workspaces(mock_opik_ctor, _mock_host):
-    from cometx.cli.admin_growth_report import GrowthReporter
-
-    proj = _make_opik_project(
-        "id1", "proj1", datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
-    )
-    fake_page = MagicMock()
-    fake_page.content = [proj]
-    fake_page.total = 1
-
-    mock_client = MagicMock()
-    mock_client.rest_client.projects.find_projects.return_value = fake_page
-    mock_client.rest_client.projects.get_project_metrics.return_value = (
-        _make_opik_metrics_response([])
-    )
-    mock_opik_ctor.return_value = mock_client
-
-    api = _make_opik_api()
-    reporter = GrowthReporter(
-        api, window="7d", units="month", platforms="opik", limit=1
-    )
-    events, usage = reporter._collect_opik(["ws1", "ws2"])
-
-    assert all(e.workspace == "ws1" for e in events)
-    assert all(m.workspace == "ws1" for m in usage)
-    assert mock_opik_ctor.call_count == 1
-
-
-@patch(
-    "cometx.cli.smoke_test.get_opik_config",
-    return_value="https://example.com/opik/api/",
-)
-@requires_opik
-@patch("opik.Opik")
-def test_collect_opik_skips_bad_workspace_and_continues(
-    mock_opik_ctor, _mock_host, capsys
-):
-    from cometx.cli.admin_growth_report import GrowthReporter
-
-    proj = _make_opik_project(
-        "id1", "proj1", datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
-    )
-    fake_page_ok = MagicMock()
-    fake_page_ok.content = [proj]
-    fake_page_ok.total = 1
-
-    good_client = MagicMock()
-    good_client.rest_client.projects.find_projects.return_value = fake_page_ok
-    good_client.rest_client.projects.get_project_metrics.return_value = (
-        _make_opik_metrics_response(
-            [(datetime.datetime(2026, 1, 2, tzinfo=datetime.timezone.utc), 4)]
-        )
-    )
-
-    def opik_ctor(workspace, **kwargs):
-        if workspace == "ws_bad":
-            raise RuntimeError("bad auth")
-        return good_client
-
-    mock_opik_ctor.side_effect = opik_ctor
-
-    api = _make_opik_api()
-    reporter = GrowthReporter(api, window="7d", units="month", platforms="opik")
-    events, usage = reporter._collect_opik(["ws_bad", "ws_good"])
-
-    assert not any(e.workspace == "ws_bad" for e in events)
-    assert any(e.workspace == "ws_good" for e in events)
-    assert any(m.workspace == "ws_good" and m.metric == "SPAN_COUNT" for m in usage)
-
-
-@requires_opik
-def test_collect_opik_emits_trace_count_alongside_spans():
-    import datetime
-
-    from cometx.cli.admin_growth_report import GrowthReporter
-
-    api = MagicMock()
-    api.config = {"comet.api_key": "K", "comet.url_override": "https://c.example.com"}
-
-    proj = MagicMock()
-    proj.name = "proj-1"
-    proj.id = "pid-1"
-    proj.created_at = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
-
-    def _metrics(project_id, metric_type, interval, interval_start, interval_end):
-        dp = MagicMock(
-            time=datetime.datetime(2026, 6, 2, tzinfo=datetime.timezone.utc),
-            value=(10 if metric_type == "SPAN_COUNT" else 3),
-        )
-        result = MagicMock(data=[dp])
-        return MagicMock(results=[result])
-
-    client = MagicMock()
-    page = MagicMock(content=[proj], total=1)
-    client.rest_client.projects.find_projects.return_value = page
-    client.rest_client.projects.get_project_metrics.side_effect = _metrics
-
-    with patch("opik.Opik", return_value=client), patch(
-        "cometx.cli.smoke_test.get_opik_config", return_value="https://c.example.com"
-    ):
-        r = GrowthReporter(api, window="7d", units="month", platforms="opik")
-        events, usage = r._collect_opik(["wsA"])
-
-    metrics = {(m.metric, m.project) for m in usage}
-    assert ("SPAN_COUNT", "proj-1") in metrics
-    assert ("TRACE_COUNT", "proj-1") in metrics
-    # workspace roll-ups (project=None) exist for both
-    assert ("SPAN_COUNT", None) in metrics
-    assert ("TRACE_COUNT", None) in metrics
-
-
-@requires_opik
-def test_collect_opik_trace_failure_keeps_spans():
-    import datetime
-
-    from cometx.cli.admin_growth_report import GrowthReporter
-
-    api = MagicMock()
-    api.config = {"comet.api_key": "K", "comet.url_override": "https://c.example.com"}
-    proj = MagicMock()
-    proj.name = "p"
-    proj.id = "id"
-    proj.created_at = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
-
-    def _metrics(project_id, metric_type, interval, interval_start, interval_end):
-        if metric_type == "TRACE_COUNT":
-            raise RuntimeError("traces boom")
-        dp = MagicMock(
-            time=datetime.datetime(2026, 6, 2, tzinfo=datetime.timezone.utc), value=5
-        )
-        return MagicMock(results=[MagicMock(data=[dp])])
-
-    client = MagicMock()
-    client.rest_client.projects.find_projects.return_value = MagicMock(
-        content=[proj], total=1
-    )
-    client.rest_client.projects.get_project_metrics.side_effect = _metrics
-
-    with patch("opik.Opik", return_value=client), patch(
-        "cometx.cli.smoke_test.get_opik_config", return_value="https://c.example.com"
-    ):
-        r = GrowthReporter(api, window="7d", units="month", platforms="opik")
-        events, usage = r._collect_opik(["wsA"])
-
-    assert any(m.metric == "SPAN_COUNT" and m.project == "p" for m in usage)
-    assert not any(m.metric == "TRACE_COUNT" and m.project == "p" for m in usage)
-
-
-def test_collect_opik_missing_dependency_returns_empty(monkeypatch):
-    import builtins
-
-    from cometx.cli.admin_growth_report import GrowthReporter
-
-    real_import = builtins.__import__
-
-    def fake_import(name, *args, **kwargs):
-        if name == "opik":
-            raise ImportError("no opik")
-        return real_import(name, *args, **kwargs)
-
-    monkeypatch.setattr(builtins, "__import__", fake_import)
-
-    api = _make_opik_api()
-    reporter = GrowthReporter(api, window="7d", units="month", platforms="opik")
-    events, usage = reporter._collect_opik(["ws1"])
-
-    assert events == []
-    assert usage == []
-
-
-def _make_mpm_api():
-    """MagicMock api with a REAL dict `.config` (see task-C6-context.md)."""
-    api = MagicMock()
-    api.config = {
-        "comet.api_key": "KEY",
-        "comet.url_override": "https://example.com/",
-    }
-    return api
-
-
-def _mpm_pred_envelope(points):
-    """points: list of (x, y) -> the verified {"data":[{"data":[...]}]} envelope."""
-    return {"data": [{"data": [{"x": x, "y": y} for x, y in points]}]}
-
-
-def _make_mpm_client(workspaces_resp, details_map, predictions_map):
-    """MagicMock comet_mpm._client with the verified MPM endpoints stubbed.
-
-    `details_map`: model_id -> details dict (or an exception instance to raise).
-    `predictions_map`: model_id -> envelope dict returned by get_nb_predictions.
-    """
-    client = MagicMock()
-
-    def fake_get(path, *args, **kwargs):
-        assert path == "api/mpm/v3/workspaces"
-        return workspaces_resp
-
-    client.get.side_effect = fake_get
-
-    def fake_get_model_details(model_id):
-        val = details_map.get(model_id, {})
-        if isinstance(val, Exception):
-            raise val
-        return val
-
-    client.get_model_details.side_effect = fake_get_model_details
-
-    def fake_get_nb_predictions(model_id, *args, **kwargs):
-        return predictions_map.get(model_id, _mpm_pred_envelope([]))
-
-    client.get_nb_predictions.side_effect = fake_get_nb_predictions
-    return client
-
-
-def _mpm_workspaces_resp(models_by_ws):
-    return {
-        "workspaces": [
-            {"workspaceName": ws, "models": models}
-            for ws, models in models_by_ws.items()
-        ]
-    }
-
-
-@requires_mpm
-@patch("comet_mpm.API")
-def test_collect_mpm_creation_scenarios_a_b_c(mock_api_ctor):
-    from cometx.cli.admin_growth_report import GrowthReporter
-
-    models_by_ws = {
-        "ws1": [
-            {"modelName": "modelA", "modelId": "idA"},
-            {"modelName": "modelB", "modelId": "idB"},
-            {"modelName": "modelC", "modelId": "idC"},
-        ]
-    }
-    workspaces_resp = _mpm_workspaces_resp(models_by_ws)
-
-    # (a) model A: details carry a creation timestamp
-    details_map = {
-        "idA": {"createdAt": 1700000000000},
-        "idB": {},  # no creation key -> falls back to first-prediction-day
-        "idC": {},  # no creation key, and no y>0 predictions -> no event
-    }
-
-    predictions_map = {
-        "idA": _mpm_pred_envelope([(1699000000000, 5), (1700500000000, 2)]),
-        "idB": _mpm_pred_envelope([(1690000000000, 0), (1691000000000, 7)]),
-        "idC": _mpm_pred_envelope([(1690000000000, 0), (1691000000000, 0)]),
-    }
-
-    client = _make_mpm_client(workspaces_resp, details_map, predictions_map)
-    mock_mpm = MagicMock()
-    mock_mpm._client = client
-    mock_api_ctor.return_value = mock_mpm
-
-    api = _make_mpm_api()
-    reporter = GrowthReporter(api, window="7d", units="month", platforms="mpm")
-    events, usage = reporter._collect_mpm(["ws1"])
-
-    by_uc = {e.use_case: e for e in events}
-
-    # (a) details timestamp -> mpm_model event at that time
-    assert "modelA" in by_uc
-    assert by_uc["modelA"].kind == "mpm_model"
-    assert by_uc["modelA"].platform == "mpm"
-    assert by_uc["modelA"].workspace == "ws1"
-    assert by_uc["modelA"].created == datetime.datetime.fromtimestamp(
-        1700000000000 / 1000, tz=datetime.timezone.utc
-    )
-
-    # (b) no details ts but predictions -> proxy event at first prediction
-    # day with y>0 (1691000000000, not the 0-value 1690000000000 point)
-    assert "modelB" in by_uc
-    assert by_uc["modelB"].created == datetime.datetime.fromtimestamp(
-        1691000000000 / 1000, tz=datetime.timezone.utc
-    )
-
-    # (c) neither details ts nor any y>0 -> no CreationEvent for modelC
-    assert "modelC" not in by_uc
-
-    # but modelC must still yield a PREDICTION_VOLUME usage metric
-    pred_metrics = [m for m in usage if m.metric == "PREDICTION_VOLUME"]
-    modelC_metric = next(m for m in pred_metrics if m.project == "modelC")
-    assert modelC_metric.value == 0
-    assert modelC_metric.platform == "mpm" and modelC_metric.workspace == "ws1"
-
-
-@requires_mpm
-@patch("comet_mpm.API")
-def test_collect_mpm_prediction_volume_usage_per_model_and_per_workspace(
-    mock_api_ctor,
-):
-    from cometx.cli.admin_growth_report import GrowthReporter
-
-    models_by_ws = {
-        "ws1": [
-            {"modelName": "modelA", "modelId": "idA"},
-            {"modelName": "modelB", "modelId": "idB"},
-        ]
-    }
-    workspaces_resp = _mpm_workspaces_resp(models_by_ws)
-    details_map = {"idA": {"createdAt": 1700000000000}, "idB": {}}
-    predictions_map = {
-        "idA": _mpm_pred_envelope([(1699000000000, 5), (1700500000000, 2)]),
-        "idB": _mpm_pred_envelope([(1691000000000, 7)]),
-    }
-
-    client = _make_mpm_client(workspaces_resp, details_map, predictions_map)
-    mock_mpm = MagicMock()
-    mock_mpm._client = client
-    mock_api_ctor.return_value = mock_mpm
-
-    api = _make_mpm_api()
-    reporter = GrowthReporter(api, window="7d", units="month", platforms="mpm")
-    _events, usage = reporter._collect_mpm(["ws1"])
-
-    pred_metrics = [m for m in usage if m.metric == "PREDICTION_VOLUME"]
-
-    modelA_metric = next(m for m in pred_metrics if m.project == "modelA")
-    assert modelA_metric.value == 7  # 5 + 2
-    assert modelA_metric.series  # non-empty over-time series
-
-    modelB_metric = next(m for m in pred_metrics if m.project == "modelB")
-    assert modelB_metric.value == 7
-
-    ws_total_metric = next(m for m in pred_metrics if m.project is None)
-    assert ws_total_metric.value == 14  # 7 + 7
-    assert ws_total_metric.workspace == "ws1"
-    assert ws_total_metric.series
-
-    # fetch-once regression guard: get_nb_predictions called exactly once
-    # per model (reused for BOTH the creation proxy and the usage metric)
-    assert client.get_nb_predictions.call_count == 2
-
-
-@requires_mpm
-@patch("comet_mpm.API")
-def test_collect_mpm_respects_limit_on_workspaces(mock_api_ctor):
-    from cometx.cli.admin_growth_report import GrowthReporter
-
-    models_by_ws = {
-        "ws1": [{"modelName": "modelA", "modelId": "idA"}],
-        "ws2": [{"modelName": "modelZ", "modelId": "idZ"}],
-    }
-    workspaces_resp = _mpm_workspaces_resp(models_by_ws)
-    details_map = {"idA": {"createdAt": 1700000000000}}
-    predictions_map = {"idA": _mpm_pred_envelope([(1700000000000, 3)])}
-
-    client = _make_mpm_client(workspaces_resp, details_map, predictions_map)
-    mock_mpm = MagicMock()
-    mock_mpm._client = client
-    mock_api_ctor.return_value = mock_mpm
-
-    api = _make_mpm_api()
-    reporter = GrowthReporter(api, window="7d", units="month", platforms="mpm", limit=1)
-    events, usage = reporter._collect_mpm(["ws1", "ws2"])
-
-    assert all(e.workspace == "ws1" for e in events)
-    assert all(m.workspace == "ws1" for m in usage)
-    assert not any(e.use_case == "modelZ" for e in events)
-
-
-@requires_mpm
-@patch("comet_mpm.API")
-def test_collect_mpm_skips_bad_model_and_continues(mock_api_ctor, capsys):
-    from cometx.cli.admin_growth_report import GrowthReporter
-
-    models_by_ws = {
-        "ws1": [
-            {"modelName": "modelBad", "modelId": "idBad"},
-            {"modelName": "modelGood", "modelId": "idGood"},
-        ]
-    }
-    workspaces_resp = _mpm_workspaces_resp(models_by_ws)
-    details_map = {"idBad": {}, "idGood": {"createdAt": 1700000000000}}
-
-    def fake_get_nb_predictions(model_id, *args, **kwargs):
-        if model_id == "idBad":
-            raise RuntimeError("boom")
-        return _mpm_pred_envelope([(1700000000000, 4)])
-
-    client = _make_mpm_client(workspaces_resp, details_map, {})
-    client.get_nb_predictions.side_effect = fake_get_nb_predictions
-    mock_mpm = MagicMock()
-    mock_mpm._client = client
-    mock_api_ctor.return_value = mock_mpm
-
-    api = _make_mpm_api()
-    reporter = GrowthReporter(api, window="7d", units="month", platforms="mpm")
-    events, usage = reporter._collect_mpm(["ws1"])
-
-    assert not any(e.use_case == "modelBad" for e in events)
-    assert any(e.use_case == "modelGood" for e in events)
-    assert any(m.project == "modelGood" for m in usage)
-    assert not any(m.project == "modelBad" for m in usage)
-
-
-@requires_mpm
-@patch("comet_mpm.API")
-def test_collect_mpm_workspaces_endpoint_error_returns_empty(mock_api_ctor):
-    from cometx.cli.admin_growth_report import GrowthReporter
-
-    client = MagicMock()
-    client.get.side_effect = RuntimeError("404")
-    mock_mpm = MagicMock()
-    mock_mpm._client = client
-    mock_api_ctor.return_value = mock_mpm
-
-    api = _make_mpm_api()
-    reporter = GrowthReporter(api, window="7d", units="month", platforms="mpm")
-    events, usage = reporter._collect_mpm(["ws1"])
-
-    assert events == []
-    assert usage == []
-
-
-@requires_mpm
-@patch("comet_mpm.API")
-def test_collect_mpm_skips_malformed_enumeration_elements(mock_api_ctor):
-    # The MPM inventory shape is unverifiable live; malformed workspace/model
-    # elements must be skipped, not crash the whole report.
-    from cometx.cli.admin_growth_report import GrowthReporter
-
-    workspaces_resp = {
-        "workspaces": [
-            "not-a-dict",  # malformed workspace entry
-            {
-                "workspaceName": "ws1",
-                "models": [
-                    "not-a-dict",  # malformed model entry
-                    {"modelName": "good", "modelId": "idG"},
-                ],
-            },
-        ]
-    }
-    predictions_map = {"idG": _mpm_pred_envelope([(1690000000000, 5)])}
-    client = _make_mpm_client(
-        workspaces_resp, details_map={}, predictions_map=predictions_map
-    )
-    mock_mpm = MagicMock()
-    mock_mpm._client = client
-    mock_api_ctor.return_value = mock_mpm
-
-    api = _make_mpm_api()
-    reporter = GrowthReporter(api, window="7d", units="month", platforms="mpm")
-    events, usage = reporter._collect_mpm(["ws1"])
-
-    # The one good model is still collected; malformed entries are ignored.
-    assert [e.use_case for e in events] == ["good"]
-    assert any(m.metric == "PREDICTION_VOLUME" and m.project == "good" for m in usage)
-
-
-def _uc_ev(platform, ws, uc, kind, y, m, d):
-    from cometx.cli.admin_growth_report import CreationEvent
-
-    return CreationEvent(
-        platform,
-        ws,
-        uc,
-        kind,
-        datetime.datetime(y, m, d, tzinfo=datetime.timezone.utc),
-    )
-
-
-def _make_mixed_workspace_events():
-    """Two workspaces w/ mixed opik_project/em_project/mpm_model events."""
-    return [
-        # ws1: 2 opik, 1 em, 1 mpm; earliest = 2026-01-02 (opik)
-        _uc_ev("opik", "ws1", "op1", "opik_project", 2026, 1, 2),
-        _uc_ev("opik", "ws1", "op2", "opik_project", 2026, 3, 1),
-        _uc_ev("em", "ws1", "em1", "em_project", 2026, 2, 1),
-        _uc_ev("mpm", "ws1", "mp1", "mpm_model", 2026, 4, 1),
-        # ws2: 1 em, 2 mpm; earliest = 2025-12-15 (em)
-        _uc_ev("em", "ws2", "em2", "em_project", 2025, 12, 15),
-        _uc_ev("mpm", "ws2", "mp2", "mpm_model", 2026, 1, 10),
-        _uc_ev("mpm", "ws2", "mp3", "mpm_model", 2026, 2, 20),
-    ]
-
-
-def test_use_cases_by_workspace_by_kind_totals_and_first_created():
-    from cometx.cli.admin_growth_report import use_cases_by_workspace
-
-    events = _make_mixed_workspace_events()
-    result = use_cases_by_workspace(events)
-
-    assert set(result.keys()) == {"ws1", "ws2"}
-
-    ws1 = result["ws1"]
-    assert ws1["use_cases_total"] == 4
-    assert ws1["by_kind"] == {"opik_project": 2, "em_project": 1, "mpm_model": 1}
-    assert ws1["first_created"] == datetime.datetime(
-        2026, 1, 2, tzinfo=datetime.timezone.utc
-    )
-
-    ws2 = result["ws2"]
-    assert ws2["use_cases_total"] == 3
-    assert ws2["by_kind"] == {"opik_project": 0, "em_project": 1, "mpm_model": 2}
-    assert ws2["first_created"] == datetime.datetime(
-        2025, 12, 15, tzinfo=datetime.timezone.utc
-    )
-
-
-def test_use_cases_by_workspace_empty_input():
-    from cometx.cli.admin_growth_report import use_cases_by_workspace
-
-    assert use_cases_by_workspace([]) == {}
-
-
-def test_unified_events_filters_to_three_use_case_kinds():
-    from cometx.cli.admin_growth_report import unified_events
-
-    events = _make_mixed_workspace_events()
-    other = _uc_ev("em", "ws1", "reg1", "registry_model", 2026, 1, 1)
-    result = unified_events(events + [other])
-
-    assert len(result) == len(events)
-    assert all(e.kind in ("opik_project", "em_project", "mpm_model") for e in result)
-    assert other not in result
-    # does not mutate input
-    assert (events + [other]) == events + [other]
-
-
-def test_unified_events_empty_input():
-    from cometx.cli.admin_growth_report import unified_events
-
-    assert unified_events([]) == []
-
-
-def test_collect_mpm_missing_dependency_returns_empty(monkeypatch):
-    import builtins
-
-    from cometx.cli.admin_growth_report import GrowthReporter
-
-    real_import = builtins.__import__
-
-    def fake_import(name, *args, **kwargs):
-        if name == "comet_mpm":
-            raise ImportError("no comet_mpm")
-        return real_import(name, *args, **kwargs)
-
-    monkeypatch.setattr(builtins, "__import__", fake_import)
-
-    api = _make_mpm_api()
-    reporter = GrowthReporter(api, window="7d", units="month", platforms="mpm")
-    events, usage = reporter._collect_mpm(["ws1"])
-
-    assert events == []
-    assert usage == []
-
-
-# ---------------------------------------------------------------------------
-# C8: self-contained HTML dashboard renderer
-# ---------------------------------------------------------------------------
 
 
 def _sample_report_data():
@@ -1257,47 +300,6 @@ def test_charts_have_interactive_hover_tooltip_infra():
     assert 'class: "guide"' in doc  # the vertical hover guide line
 
 
-def test_adoption_fastest_growing_always_present():
-    # The fastest-growing-project KPI is shown for every product (incl. EM),
-    # with "—" when nothing grew in the window, so it never looks missing.
-    import datetime as dt
-
-    from cometx.cli.admin_growth_report import GrowthReporter, UsageMetric, Window
-
-    reporter = GrowthReporter(MagicMock(), window="7d", units="month", platforms="em")
-    window = Window(
-        dt.datetime(2026, 7, 1, tzinfo=dt.timezone.utc),
-        dt.datetime(2026, 7, 8, tzinfo=dt.timezone.utc),
-        "month",
-    )
-
-    # in-window activity -> the project is named
-    usage_active = [
-        UsageMetric(
-            "em", "ws", "EXPERIMENT_COUNT", 4, project="p1", series=[("2026-07", 4)]
-        ),
-        UsageMetric(
-            "em", "ws", "EXPERIMENT_COUNT", 4, project=None, series=[("2026-07", 4)]
-        ),
-    ]
-    kpis = reporter._build_adoption_section("em", usage_active, window)["kpis"]
-    fg = next(k for k in kpis if k["label"] == "Fastest-growing project")
-    assert fg["value"] == "p1" and "+4" in fg["sub"]
-
-    # no in-window activity (all before the window) -> still present, as "—"
-    usage_stale = [
-        UsageMetric(
-            "em", "ws", "EXPERIMENT_COUNT", 9, project="p1", series=[("2026-01", 9)]
-        ),
-        UsageMetric(
-            "em", "ws", "EXPERIMENT_COUNT", 9, project=None, series=[("2026-01", 9)]
-        ),
-    ]
-    kpis = reporter._build_adoption_section("em", usage_stale, window)["kpis"]
-    fg = next(k for k in kpis if k["label"] == "Fastest-growing project")
-    assert fg["value"] == "—"
-
-
 def test_build_html_escapes_workspace_and_project_names():
     from cometx.cli.admin_growth_report import build_html
 
@@ -1424,367 +426,6 @@ def test_parse_window_rejects_malformed_spec():
             pass
 
 
-def _kind_events(kind, platform, specs):
-    """specs: list of (workspace, use_case, y, m, d)."""
-    from cometx.cli.admin_growth_report import CreationEvent
-
-    return [
-        CreationEvent(
-            platform,
-            ws,
-            uc,
-            kind,
-            datetime.datetime(y, m, d, tzinfo=datetime.timezone.utc),
-        )
-        for ws, uc, y, m, d in specs
-    ]
-
-
-def _usage_metric(platform, ws, metric, value, project=None, series=None):
-    from cometx.cli.admin_growth_report import UsageMetric
-
-    return UsageMetric(
-        platform=platform,
-        workspace=ws,
-        metric=metric,
-        value=value,
-        project=project,
-        series=series,
-    )
-
-
-def _patch_collectors(monkeypatch, em=None, opik=None, mpm=None, force_platforms=None):
-    from cometx.cli.admin_growth_report import GrowthReporter
-
-    monkeypatch.setattr(
-        GrowthReporter, "_collect_em", lambda self, ws: (em or ([], []))
-    )
-    monkeypatch.setattr(
-        GrowthReporter, "_collect_opik", lambda self, ws: (opik or ([], []))
-    )
-    monkeypatch.setattr(
-        GrowthReporter, "_collect_mpm", lambda self, ws: (mpm or ([], []))
-    )
-    # Decouple platform resolution from the environment: `_resolve_platforms`
-    # imports opik/comet_mpm to decide availability, but these are optional
-    # extras not always installed in CI. Force the set so cross-platform
-    # assembly tests are deterministic regardless of what's pip-installed.
-    if force_platforms is not None:
-        monkeypatch.setattr(
-            GrowthReporter, "_resolve_platforms", lambda self: list(force_platforms)
-        )
-
-
-def test_build_assembles_report_data_matching_c8_contract(monkeypatch):
-    from cometx.cli.admin_growth_report import GrowthReporter
-
-    opik_events = _kind_events(
-        "opik_project",
-        "opik",
-        [
-            ("ws-alpha", "op1", 2026, 6, 1),
-            ("ws-alpha", "op2", 2026, 7, 5),
-            ("ws-beta", "op3", 2026, 7, 6),
-        ],
-    )
-    em_events = _kind_events(
-        "em_project",
-        "em",
-        [("ws-alpha", "em1", 2026, 5, 1), ("ws-beta", "em2", 2026, 7, 8)],
-    )
-    mpm_events = _kind_events("mpm_model", "mpm", [("ws-beta", "mp1", 2026, 7, 7)])
-    opik_usage = [
-        _usage_metric(
-            "opik",
-            "ws-alpha",
-            "SPAN_COUNT",
-            100,
-            project="op1",
-            series=[("2026-07", 100)],
-        ),
-        _usage_metric(
-            "opik",
-            "ws-alpha",
-            "SPAN_COUNT",
-            100,
-            project=None,
-            series=[("2026-07", 100)],
-        ),
-    ]
-    em_usage = [
-        _usage_metric(
-            "em",
-            "ws-alpha",
-            "EXPERIMENT_COUNT",
-            10,
-            project="em1",
-            series=[("2026-07", 10)],
-        ),
-        _usage_metric(
-            "em",
-            "ws-alpha",
-            "EXPERIMENT_COUNT",
-            10,
-            project=None,
-            series=[("2026-07", 10)],
-        ),
-        _usage_metric("em", "ws-alpha", "REGISTRY_MODELS", 2, project=None),
-        _usage_metric("em", "ws-alpha", "REGISTRY_VERSIONS", 3, project=None),
-    ]
-    mpm_usage = [
-        _usage_metric(
-            "mpm",
-            "ws-beta",
-            "PREDICTION_VOLUME",
-            50,
-            project="mp1",
-            series=[("2026-07", 50)],
-        ),
-        _usage_metric(
-            "mpm",
-            "ws-beta",
-            "PREDICTION_VOLUME",
-            50,
-            project=None,
-            series=[("2026-07", 50)],
-        ),
-    ]
-
-    _patch_collectors(
-        monkeypatch,
-        em=(em_events, em_usage),
-        opik=(opik_events, opik_usage),
-        mpm=(mpm_events, mpm_usage),
-        force_platforms=["opik", "em", "mpm"],
-    )
-
-    reporter = GrowthReporter(
-        MagicMock(), window="7d", units="month", platforms="em,opik,mpm"
-    )
-    monkeypatch.setattr(GrowthReporter, "_now", lambda self: _now())
-    report_data = reporter.build(["ws-alpha", "ws-beta"])
-
-    assert report_data["collectors"] == {"opik": True, "em": True, "mpm": True}
-
-    window = report_data["window"]
-    assert window["units"] == "month"
-    assert "7d" in window["label"]
-
-    unified = report_data["sections"]["unified"]
-    # Chargeback fetch is mocked to fail here, so the section falls back to the
-    # SDK (accessible-workspaces) view.
-    assert unified["title"] == "Workspaces & projects (accessible)"
-    kpi_labels = [k["label"] for k in unified["kpis"]]
-    assert "Total workspaces" in kpi_labels
-    assert "Departments" not in kpi_labels
-    assert "Total projects" in kpi_labels
-    projects_kpi = next(k for k in unified["kpis"] if k["label"] == "Total projects")
-    assert projects_kpi["value"] == 6  # 3 opik + 2 em + 1 mpm
-
-    # projects-created chart is stacked by kind (Opik/EM/MPM projects)
-    kinds_chart = next(
-        c for c in unified["charts"] if c["id"] == "chart-unified-created"
-    )
-    assert kinds_chart["data"]["categories"] == [
-        "opik_project",
-        "em_project",
-        "mpm_model",
-    ]
-    # the per-workspace breakdown now lives only in the unified table (the
-    # "Projects by workspace" chart was removed); the summary charts are the
-    # four created/cumulative workspace + project series
-    chart_ids = [c["id"] for c in unified["charts"]]
-    assert "chart-unified-by-workspace" not in chart_ids
-    assert "chart-unified-workspaces-cumulative" in chart_ids
-    assert "chart-unified-projects-cumulative" in chart_ids
-
-    # multi-workspace -> unified table breaks down by workspace
-    assert unified["table"]["title"] == "By workspace"
-    assert unified["table"]["headers"][0] == "Workspace"
-    ws_rows = {row[0] for row in unified["table"]["rows"]}
-    assert ws_rows == {"ws-alpha", "ws-beta"}
-
-    products = report_data["sections"]["products"]
-    assert set(products.keys()) == {"opik", "em", "mpm"}
-
-    opik_growth = products["opik"]["growth"]
-    assert opik_growth["kpis"][1]["label"] == "Total"
-    assert opik_growth["kpis"][1]["value"] == 3  # 3 opik_project events total
-    bars_chart = next(c for c in opik_growth["charts"] if c["kind"] == "bars")
-    assert sum(p["value"] for p in bars_chart["data"]["points"]) == 3
-    area_chart = next(c for c in opik_growth["charts"] if c["kind"] == "area")
-    assert area_chart["data"]["points"][-1]["value"] == 3
-
-    em_adoption = products["em"]["adoption"]
-    registry_panel = next(
-        p
-        for p in em_adoption.get("panels", [])
-        if p["title"] == "Model-registry engagement"
-    )
-    assert registry_panel["rows"] == [["ws-alpha", 2, 3]]
-
-    # adoption sections carry usage growth (not just totals) + a cumulative chart
-    em_adoption_kpis = {k["label"]: k for k in em_adoption["kpis"]}
-    assert em_adoption_kpis["Experiment count"]["value"] == 10
-    assert any(lbl.startswith("New (") for lbl in em_adoption_kpis)
-    assert any(lbl.startswith("Growth (") for lbl in em_adoption_kpis)
-    # em1 is the only project with in-window experiments -> fastest-growing
-    assert em_adoption_kpis["Fastest-growing project"]["value"] == "em1"
-    adoption_chart_kinds = {c["kind"] for c in em_adoption["charts"]}
-    assert "bars" in adoption_chart_kinds and "area" in adoption_chart_kinds
-
-    mpm_growth = products["mpm"]["growth"]
-    assert mpm_growth["kpis"][1]["value"] == 1
-
-    # never a secret anywhere in the assembled data
-    dumped = str(report_data)
-    assert "COMET_API_KEY" not in dumped
-    assert "sk-" not in dumped
-
-
-def test_build_resolves_workspaces_via_api_when_none_given(monkeypatch):
-    from cometx.cli.admin_growth_report import GrowthReporter
-
-    _patch_collectors(monkeypatch)
-    api = MagicMock()
-    api.get_workspaces.return_value = ["ws-only"]
-    reporter = GrowthReporter(api, window="7d", units="month", platforms="em")
-    report_data = reporter.build([])
-
-    api.get_workspaces.assert_called_once()
-    assert report_data["sections"]["unified"]["kpis"][0]["value"] == 1
-
-
-def test_build_drops_unimportable_optional_platforms(monkeypatch):
-    import builtins
-
-    from cometx.cli.admin_growth_report import GrowthReporter
-
-    real_import = builtins.__import__
-
-    def fake_import(name, *args, **kwargs):
-        if name == "opik":
-            raise ImportError("no opik")
-        return real_import(name, *args, **kwargs)
-
-    monkeypatch.setattr(builtins, "__import__", fake_import)
-    _patch_collectors(monkeypatch)
-
-    reporter = GrowthReporter(
-        MagicMock(), window="7d", units="month", platforms="em,opik,mpm"
-    )
-    report_data = reporter.build(["ws1"])
-
-    assert report_data["collectors"]["opik"] is False
-    assert "opik" not in report_data["sections"]["products"]
-
-
-def test_build_single_workspace_breaks_down_unified_table_by_use_case(monkeypatch):
-    from cometx.cli.admin_growth_report import GrowthReporter
-
-    opik_events = _kind_events("opik_project", "opik", [("ws1", "op1", 2026, 6, 1)])
-    _patch_collectors(monkeypatch, opik=(opik_events, []))
-
-    reporter = GrowthReporter(MagicMock(), window="7d", units="month", platforms="opik")
-    report_data = reporter.build(["ws1"])
-
-    unified_table = report_data["sections"]["unified"]["table"]
-    assert unified_table["headers"][0] == "Project"
-    assert unified_table["rows"] == [["op1", "Opik projects", "2026-06-01"]]
-
-
-def test_generate_growth_report_writes_html_with_no_secret(monkeypatch, tmp_path):
-    from cometx.cli.admin_growth_report import generate_growth_report
-
-    opik_events = _kind_events(
-        "opik_project", "opik", [("ws1", "op1", 2026, 6, 1), ("ws1", "op2", 2026, 7, 8)]
-    )
-    _patch_collectors(monkeypatch, opik=(opik_events, []))
-
-    out = tmp_path / "growth.html"
-    api = MagicMock()
-    api.config = {"comet.api_key": "sk-should-never-leak-0000"}
-    path = generate_growth_report(
-        api,
-        ["ws1"],
-        window="7d",
-        units="month",
-        platforms="opik",
-        output=str(out),
-        no_open=True,
-    )
-
-    content = out.read_text(encoding="utf-8")
-    assert path == str(out)
-    assert "Workspaces & projects" in content
-    assert "op1" in content or "op2" in content
-    assert "sk-should-never-leak-0000" not in content
-
-
-def test_generate_growth_report_full_chain_all_platforms(monkeypatch, tmp_path):
-    """End-to-end seam coverage: fixed collector output -> build() ->
-    build_html() -> the written HTML file, across all three platforms.
-    Chains what test_build_assembles_report_data_matching_c8_contract and
-    the render-layer tests otherwise only cover separately."""
-    from cometx.cli.admin_growth_report import generate_growth_report
-
-    monkeypatch.setenv("COMET_API_KEY", "sk-planted-env-secret-should-not-leak")
-
-    opik_events = _kind_events(
-        "opik_project",
-        "opik",
-        [
-            ("ws-alpha", "op1", 2026, 6, 1),
-            ("ws-alpha", "op2", 2026, 7, 5),
-            ("ws-beta", "op3", 2026, 7, 6),
-        ],
-    )
-    em_events = _kind_events(
-        "em_project",
-        "em",
-        [("ws-alpha", "em1", 2026, 5, 1), ("ws-beta", "em2", 2026, 7, 8)],
-    )
-    mpm_events = _kind_events("mpm_model", "mpm", [("ws-beta", "mp1", 2026, 7, 7)])
-    _patch_collectors(
-        monkeypatch,
-        em=(em_events, []),
-        opik=(opik_events, []),
-        mpm=(mpm_events, []),
-        force_platforms=["opik", "em", "mpm"],
-    )
-
-    out = tmp_path / "growth-full-chain.html"
-    api = MagicMock()
-    api.config = {"comet.api_key": "sk-api-secret-should-not-leak"}
-    path = generate_growth_report(
-        api,
-        ["ws-alpha", "ws-beta"],
-        window="7d",
-        units="month",
-        platforms="em,opik,mpm",
-        output=str(out),
-        no_open=True,
-    )
-
-    content = out.read_text(encoding="utf-8")
-    assert path == str(out)
-
-    # Section titles from all three product sections + the unified section.
-    assert "Workspaces & projects" in content
-    assert "Opik — growth" in content
-    assert "EM — growth" in content
-    assert "MPM — growth" in content
-
-    # KPI value derived from the fixed events: 3 opik + 2 em + 1 mpm = 6
-    # total use cases in the unified section.
-    assert ">6<" in content
-
-    # No secret (env-planted or api-config) ever reaches the rendered HTML.
-    assert "sk-planted-env-secret-should-not-leak" not in content
-    assert "sk-api-secret-should-not-leak" not in content
-    assert "COMET_API_KEY" not in content
-
-
 def test_people_section_built_from_chargeback():
     from cometx.cli.admin_growth_report import GrowthReporter
 
@@ -1812,9 +453,7 @@ def test_people_section_built_from_chargeback():
         api,
         window="7d",
         units="month",
-        platforms="em",
         active_window="60d",
-        include_users=True,
         leaderboard_top_n=5,
     )
     from cometx.cli.admin_growth_users import parse_users
@@ -1867,36 +506,12 @@ def test_people_section_user_growth_kpi_with_window():
         },
     }
     api = MagicMock()
-    r = GrowthReporter(
-        api, window="7d", units="month", platforms="em", active_window="60d"
-    )
+    r = GrowthReporter(api, window="7d", units="month", active_window="60d")
     section = r._build_people_section(parse_users(cb), now_ms=now_ms, window=_win())
     growth = next(k for k in section["kpis"] if k["label"].startswith("New in"))
     # one new account in-window vs two before => 50%, "+1 new"
     assert growth["value"] == "50.0%"
     assert growth["sub"] == "+1 new"
-
-
-def test_include_users_false_skips_people(monkeypatch):
-    from cometx.cli.admin_growth_report import GrowthReporter
-
-    api = MagicMock()
-    r = GrowthReporter(
-        api, window="7d", units="month", platforms="em", include_users=False
-    )
-    # build() must not call fetch_chargeback_report when include_users is False
-    import cometx.cli.admin_growth_report as agr
-
-    called = {"n": 0}
-    monkeypatch.setattr(
-        agr,
-        "fetch_chargeback_report",
-        lambda *a, **k: called.__setitem__("n", called["n"] + 1) or {},
-    )
-    r.api.get_workspaces.return_value = []
-    data = r.build([])
-    assert "people" not in data["sections"]
-    assert called["n"] == 0
 
 
 def test_malformed_chargeback_degrades_people_section_without_crashing(monkeypatch):
@@ -1920,9 +535,7 @@ def test_malformed_chargeback_degrades_people_section_without_crashing(monkeypat
         api,
         window="7d",
         units="month",
-        platforms="em",
         active_window="60d",
-        include_users=True,
         leaderboard_top_n=5,
     )
 
@@ -1959,9 +572,7 @@ def test_malformed_chargeback_degrades_leaderboards_and_personal_vs_service(
         api,
         window="7d",
         units="month",
-        platforms="em",
         active_window="60d",
-        include_users=True,
         leaderboard_top_n=5,
     )
 
@@ -1975,43 +586,6 @@ def test_malformed_chargeback_degrades_leaderboards_and_personal_vs_service(
     assert "referenced before assignment" not in captured.out
     assert "not associated with a value" not in captured.out
     assert "leaderboard_users" not in captured.out
-
-
-def test_leaderboards_rank_workspaces_top_n():
-    from cometx.cli.admin_growth_report import GrowthReporter, UsageMetric
-
-    api = MagicMock()
-    r = GrowthReporter(
-        api, window="7d", units="month", platforms="em", leaderboard_top_n=2
-    )
-    usage = [
-        UsageMetric("em", "wsA", "EXPERIMENT_COUNT", 100, project=None, series=[]),
-        UsageMetric("em", "wsB", "EXPERIMENT_COUNT", 50, project=None, series=[]),
-        UsageMetric("em", "wsC", "EXPERIMENT_COUNT", 10, project=None, series=[]),
-    ]
-    section = r._build_leaderboards_section(
-        usage=usage, users=[], ran={"em": True, "opik": False, "mpm": False}
-    )
-    charts = section["charts"]
-    # a workspace-by-experiments groupedBarsH exists, top-2 only
-    exp_chart = next(
-        c
-        for c in charts
-        if "experiment" in c["title"].lower() and "top" in c["title"].lower()
-    )
-    rows = exp_chart["data"]["rows"]
-    assert [row["label"] for row in rows] == ["wsA", "wsB"]
-
-
-def test_leaderboards_omit_platform_that_did_not_run():
-    from cometx.cli.admin_growth_report import GrowthReporter
-
-    api = MagicMock()
-    r = GrowthReporter(api, window="7d", units="month", platforms="em")
-    section = r._build_leaderboards_section(
-        usage=[], users=[], ran={"em": False, "opik": False, "mpm": False}
-    )
-    assert section is None or not section.get("charts")
 
 
 def test_fetch_service_accounts_parses_name_list():
@@ -2081,7 +655,7 @@ def test_build_personal_vs_service_section_admin_api_source():
     from cometx.cli.admin_growth_users import parse_users
 
     api = MagicMock()
-    r = GrowthReporter(api, window="7d", units="month", platforms="em")
+    r = GrowthReporter(api, window="7d", units="month")
     cb = {
         "workspaces": [],
         "users": {
@@ -2124,7 +698,7 @@ def test_build_personal_vs_service_section_heuristic_fallback_omits_empty_metric
     from cometx.cli.admin_growth_users import parse_users
 
     api = MagicMock()
-    r = GrowthReporter(api, window="7d", units="month", platforms="em")
+    r = GrowthReporter(api, window="7d", units="month")
     cb = {
         "workspaces": [],
         "users": {
@@ -2163,7 +737,7 @@ def test_build_personal_vs_service_section_none_when_no_users():
     from cometx.cli.admin_growth_report import GrowthReporter
 
     api = MagicMock()
-    r = GrowthReporter(api, window="7d", units="month", platforms="em")
+    r = GrowthReporter(api, window="7d", units="month")
     assert r._build_personal_vs_service_section([], service_account_names=None) is None
 
 
@@ -2210,9 +784,7 @@ def test_assemble_report_data_wires_personal_vs_service_section(monkeypatch):
         api,
         window="7d",
         units="month",
-        platforms="em",
         active_window="60d",
-        include_users=True,
         leaderboard_top_n=5,
     )
     data = r.build([])
@@ -2260,94 +832,12 @@ def test_assemble_report_data_degrades_personal_vs_service_without_crashing(
         api,
         window="7d",
         units="month",
-        platforms="em",
         active_window="60d",
-        include_users=True,
         leaderboard_top_n=5,
     )
     data = r.build([])  # must not raise
 
     assert "personal_vs_service" not in data["sections"]
-
-
-def test_exclude_personal_filters_by_pattern():
-    from cometx.cli.admin_growth_report import GrowthReporter
-
-    api = MagicMock()
-    r = GrowthReporter(
-        api,
-        window="7d",
-        units="month",
-        platforms="em",
-        exclude_personal=True,
-        personal_pattern=r"^user-",
-    )
-    kept = r._filter_personal(["team-a", "user-alice", "team-b"])
-    assert kept == ["team-a", "team-b"]
-
-
-def test_exclude_personal_without_pattern_is_noop():
-    from cometx.cli.admin_growth_report import GrowthReporter
-
-    api = MagicMock()
-    r = GrowthReporter(
-        api,
-        window="7d",
-        units="month",
-        platforms="em",
-        exclude_personal=True,
-        personal_pattern=None,
-    )
-    assert r._filter_personal(["a", "b"]) == ["a", "b"]
-
-
-def test_workspace_first_events_and_cumulative_growth():
-    import datetime
-
-    from cometx.cli.admin_growth_report import CreationEvent, GrowthReporter
-
-    api = MagicMock()
-    api.config = {"comet.url_override": "https://c.example.com"}
-
-    def ev(ws, y, m):
-        return CreationEvent(
-            "opik",
-            ws,
-            f"{ws}-{y}-{m}",
-            "opik_project",
-            datetime.datetime(y, m, 1, tzinfo=datetime.timezone.utc),
-        )
-
-    # A first seen Jan (has a later Feb project too -> must dedup to Jan),
-    # B/C Feb, D Mar -> workspace cumulative total 1,3,4
-    events = [
-        ev("A", 2024, 1),
-        ev("A", 2024, 2),
-        ev("B", 2024, 2),
-        ev("C", 2024, 2),
-        ev("D", 2024, 3),
-    ]
-    r = GrowthReporter(api, window="7d", units="month", platforms="opik")
-
-    ws_events = r._workspace_first_events(events)
-    # one event per workspace, at its earliest month
-    assert {e.workspace: e.created.strftime("%Y-%m") for e in ws_events} == {
-        "A": "2024-01",
-        "B": "2024-02",
-        "C": "2024-02",
-        "D": "2024-03",
-    }
-
-    chart = r._cumulative_area_chart(
-        ws_events, "chart-unified-workspaces-cumulative", "Total workspaces over time"
-    )
-    assert chart["kind"] == "area"
-    totals = {p["key"]: p["value"] for p in chart["data"]["points"]}
-    assert totals == {"2024-01": 1, "2024-02": 3, "2024-03": 4}
-    # no obsolete window band on the growth curve
-    assert chart["data"]["window_start"] is None
-    # a single period is not enough of a trajectory to plot -> no chart
-    assert r._cumulative_area_chart([ev("A", 2024, 1)], "id", "t") is None
 
 
 def _cb_lb():
@@ -2403,15 +893,13 @@ def test_scope_chargeback_filters_workspaces_and_users():
 def test_scope_label_org_vs_scoped():
     from cometx.cli.admin_growth_report import GrowthReporter
 
-    org = GrowthReporter._scope_label(None, 4, 165, 137, True)
+    org = GrowthReporter._scope_label(None, 165, 137)
     assert org.startswith("Org-wide: 165 workspaces, 137 users")
-    assert "4 workspace(s)" in org
-    assert GrowthReporter._scope_label({"a", "b"}, 2, 165, 137, True) == (
+    assert org.endswith("(chargeback)")
+    assert GrowthReporter._scope_label({"a", "b"}, 165, 137) == (
         "Scoped to 2 selected workspace(s)"
     )
-    assert "accessible to this key: 4" in GrowthReporter._scope_label(
-        None, 4, None, None, False
-    )
+    assert GrowthReporter._scope_label(None, None, None) == "Org-wide (chargeback)"
 
 
 def test_leaderboards_workspaces_org_wide_from_chargeback():
@@ -2447,13 +935,9 @@ def test_leaderboards_workspaces_org_wide_from_chargeback():
         },
     }
     api = MagicMock()
-    r = GrowthReporter(
-        api, window="7d", units="month", platforms="em,opik", leaderboard_top_n=5
-    )
+    r = GrowthReporter(api, window="7d", units="month", leaderboard_top_n=5)
     section = r._build_leaderboards_section(
-        usage=[],
         users=parse_users(cb),
-        ran={"em": True, "opik": True, "mpm": False},
         ws_records=parse_workspaces(cb),
     )
     exp_top = next(
@@ -2514,11 +998,9 @@ def test_unified_section_org_overview_from_chargeback():
         },
     }
     api = MagicMock()
-    r = GrowthReporter(api, window="7d", units="month", platforms="em,opik")
+    r = GrowthReporter(api, window="7d", units="month")
     section = r._build_unified_section(
-        [],
         _win(),
-        0,
         people_users=parse_users(cb),
         ws_records=parse_workspaces(cb),
         now_ms=now_ms,
@@ -2550,9 +1032,46 @@ def test_unified_section_org_overview_from_chargeback():
     assert section["table"]["title"] == "By workspace (org-wide, chargeback)"
 
 
-def test_leaderboards_omit_traces_board():
+def test_build_raises_when_chargeback_unavailable(monkeypatch):
+    import cometx.cli.admin_growth_report as agr
+    from cometx.cli.admin_growth_report import GrowthReporter, GrowthReportError
+
+    def boom(*a, **k):
+        raise RuntimeError("status_code: 403, body: {'message': 'Forbidden'}")
+
+    monkeypatch.setattr(agr, "fetch_chargeback_report", boom)
+    api = MagicMock()
+    r = GrowthReporter(api, window="7d", units="month")
+    try:
+        r.build([])
+        assert False, "expected GrowthReportError"
+    except GrowthReportError as exc:
+        assert "admin API key" in str(exc)
+
+
+def test_generate_growth_report_signature_has_no_sdk_kwargs():
+    import inspect
+
+    from cometx.cli.admin_growth_report import generate_growth_report
+
+    params = inspect.signature(generate_growth_report).parameters
+    for gone in ("platforms", "limit", "include_users"):
+        assert gone not in params
+    for kept in (
+        "window",
+        "units",
+        "active_window",
+        "leaderboard_top_n",
+        "exclude_personal",
+        "personal_pattern",
+        "output",
+        "no_open",
+    ):
+        assert kept in params
+
+
+def test_exclude_personal_drops_matching_workspaces_from_chargeback():
     from cometx.cli.admin_growth_report import GrowthReporter
-    from cometx.cli.admin_growth_users import parse_users, parse_workspaces
 
     cb = {
         "workspaces": [
@@ -2561,19 +1080,34 @@ def test_leaderboards_omit_traces_board():
                 "numberOfExperiments": 5,
                 "projects": [{}],
                 "members": [{"userName": "a"}],
-            }
+            },
+            {
+                "name": "personal-bob",
+                "numberOfExperiments": 1,
+                "projects": [{}],
+                "members": [{"userName": "bob"}],
+            },
         ],
-        "users": {"licensedUsers": [{"username": "a", "email": "a", "lastUsedAt": 1}]},
+        "users": {
+            "report": [
+                {"username": "a", "email": "a", "lastUsedAt": 1},
+                {"username": "bob", "email": "b", "lastUsedAt": 1},
+            ]
+        },
     }
     api = MagicMock()
-    r = GrowthReporter(api, window="7d", units="month", platforms="em,opik")
-    section = r._build_leaderboards_section(
-        usage=[],
-        users=parse_users(cb),
-        ran={"em": True, "opik": True, "mpm": False},
-        ws_records=parse_workspaces(cb),
+    r = GrowthReporter(
+        api,
+        window="7d",
+        units="month",
+        exclude_personal=True,
+        personal_pattern=r"^personal-",
     )
-    assert not any("traces" in c["id"] for c in section["charts"])
+    filtered = r._filter_personal_chargeback(cb)
+    names = [w["name"] for w in filtered["workspaces"]]
+    assert names == ["team-a"]
+    # original is not mutated
+    assert len(cb["workspaces"]) == 2
 
 
 def test_short_api_error_condenses_verbose_sdk_error():
@@ -2587,31 +1121,3 @@ def test_short_api_error_condenses_verbose_sdk_error():
     assert _short_api_error("plain boom") == "plain boom"
     long = "x" * 300
     assert len(_short_api_error(long)) <= 160
-
-
-def test_growth_rate_chart_period_over_period():
-    import datetime
-
-    from cometx.cli.admin_growth_report import CreationEvent, GrowthReporter
-
-    api = MagicMock()
-    api.config = {"comet.url_override": "https://c.example.com"}
-
-    def ev(y, m):
-        return CreationEvent(
-            "opik",
-            "w",
-            f"p{y}{m}",
-            "opik_project",
-            datetime.datetime(y, m, 1, tzinfo=datetime.timezone.utc),
-        )
-
-    # new per month: Jan 1, Feb 2, Mar 1 -> cumulative 1,3,4 -> rate 0, 200, 33.3
-    events = [ev(2024, 1), ev(2024, 2), ev(2024, 2), ev(2024, 3)]
-    r = GrowthReporter(api, window="7d", units="month", platforms="opik")
-    c = r._growth_rate_chart(events, "chart-x", "Growth rate")
-    assert c["kind"] == "lines"
-    rates = {p["key"]: p["values"]["rate"] for p in c["data"]["points"]}
-    assert rates == {"2024-01": 0.0, "2024-02": 200.0, "2024-03": 33.3}
-    # single period -> no rate
-    assert r._growth_rate_chart([ev(2024, 1)], "x", "t") is None

--- a/tests/unit/test_admin_growth_report.py
+++ b/tests/unit/test_admin_growth_report.py
@@ -1792,10 +1792,45 @@ def test_include_users_false_skips_people(monkeypatch):
     r = GrowthReporter(api, window="7d", units="month", platforms="em",
                        include_users=False)
     # build() must not call fetch_chargeback_report when include_users is False
-    import cometx.utils as U
+    import cometx.cli.admin_growth_report as agr
     called = {"n": 0}
-    monkeypatch.setattr(U, "fetch_chargeback_report", lambda *a, **k: called.__setitem__("n", called["n"] + 1) or {})
+    monkeypatch.setattr(
+        agr,
+        "fetch_chargeback_report",
+        lambda *a, **k: called.__setitem__("n", called["n"] + 1) or {},
+    )
     r.api.get_workspaces.return_value = []
     data = r.build([])
     assert "people" not in data["sections"]
     assert called["n"] == 0
+
+
+def test_malformed_chargeback_degrades_people_section_without_crashing(monkeypatch):
+    """A chargeback fetch that succeeds but returns a shape parse_users()
+    cannot handle must degrade to no people section, not crash build()."""
+    from cometx.cli.admin_growth_report import GrowthReporter
+    import cometx.cli.admin_growth_report as agr
+
+    api = MagicMock()
+    api.config = {"comet.url_override": "https://c.example.com"}
+    api.api_key = "K"
+    api.get_workspaces.return_value = []
+
+    # Malformed-but-successfully-fetched payload: a licensed-user entry that
+    # is a plain string, not a dict, so parse_users()'s `raw.get(...)` call
+    # raises AttributeError instead of returning parsed records.
+    malformed = {"workspaces": [], "users": {"licensedUsers": ["not-a-dict"]}}
+    monkeypatch.setattr(agr, "fetch_chargeback_report", lambda *a, **k: malformed)
+
+    r = GrowthReporter(
+        api,
+        window="7d",
+        units="month",
+        platforms="em",
+        active_window="60d",
+        include_users=True,
+        leaderboard_top_n=5,
+    )
+
+    data = r.build([])  # must not raise
+    assert "people" not in data["sections"]

--- a/tests/unit/test_admin_growth_report.py
+++ b/tests/unit/test_admin_growth_report.py
@@ -1834,3 +1834,30 @@ def test_malformed_chargeback_degrades_people_section_without_crashing(monkeypat
 
     data = r.build([])  # must not raise
     assert "people" not in data["sections"]
+
+
+def test_leaderboards_rank_workspaces_top_n():
+    from cometx.cli.admin_growth_report import GrowthReporter, UsageMetric
+    api = MagicMock()
+    r = GrowthReporter(api, window="7d", units="month", platforms="em", leaderboard_top_n=2)
+    usage = [
+        UsageMetric("em", "wsA", "EXPERIMENT_COUNT", 100, project=None, series=[]),
+        UsageMetric("em", "wsB", "EXPERIMENT_COUNT", 50, project=None, series=[]),
+        UsageMetric("em", "wsC", "EXPERIMENT_COUNT", 10, project=None, series=[]),
+    ]
+    section = r._build_leaderboards_section(
+        usage=usage, users=[], ran={"em": True, "opik": False, "mpm": False})
+    charts = section["charts"]
+    # a workspace-by-experiments groupedBarsH exists, top-2 only
+    exp_chart = next(c for c in charts if "experiment" in c["title"].lower() and "top" in c["title"].lower())
+    rows = exp_chart["data"]["rows"]
+    assert [row["label"] for row in rows] == ["wsA", "wsB"]
+
+
+def test_leaderboards_omit_platform_that_did_not_run():
+    from cometx.cli.admin_growth_report import GrowthReporter
+    api = MagicMock()
+    r = GrowthReporter(api, window="7d", units="month", platforms="em")
+    section = r._build_leaderboards_section(usage=[], users=[],
+        ran={"em": False, "opik": False, "mpm": False})
+    assert section is None or not section.get("charts")

--- a/tests/unit/test_admin_growth_report.py
+++ b/tests/unit/test_admin_growth_report.py
@@ -1891,6 +1891,40 @@ def test_fetch_service_accounts_returns_none_on_failure():
     assert _fetch_service_accounts(api) is None
 
 
+def _fetch_with_payload(payload):
+    from cometx.cli.admin_growth_report import _fetch_service_accounts
+
+    api = MagicMock()
+    api.config = {"comet.url_override": "https://c.example.com"}
+    api.api_key = "K"
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = payload
+    api._client.get.return_value = resp
+    return _fetch_service_accounts(api)
+
+
+def test_fetch_service_accounts_returns_none_on_unrecognized_shape():
+    # A successful response whose shape isn't a list and doesn't carry any
+    # known container key -- unparseable, so callers must fall back to the
+    # regex heuristic (None), not silently report zero service accounts.
+    assert _fetch_with_payload({"weird": 123}) is None
+
+
+def test_fetch_service_accounts_returns_none_when_entries_all_unparseable():
+    # A recognized bare-list container, but every entry is a type we can't
+    # extract a name from -- still unparseable overall, so None (not an
+    # empty set, which would misleadingly imply "admin API says zero").
+    assert _fetch_with_payload([1, 2, 3]) is None
+
+
+def test_fetch_service_accounts_returns_empty_set_for_genuinely_empty_container():
+    # A recognized, genuinely-empty container IS a real "zero service
+    # accounts" answer from the admin API -- keep it as an empty set (not
+    # None) so classify_accounts still reports source="admin_api".
+    assert _fetch_with_payload({"serviceAccounts": []}) == set()
+    assert _fetch_with_payload([]) == set()
+
+
 def test_build_personal_vs_service_section_admin_api_source():
     from cometx.cli.admin_growth_report import GrowthReporter
     from cometx.cli.admin_growth_users import parse_users

--- a/tests/unit/test_admin_growth_report.py
+++ b/tests/unit/test_admin_growth_report.py
@@ -909,7 +909,7 @@ def test_scope_label_org_vs_scoped():
     assert org.startswith("Org-wide: 165 workspaces, 137 users")
     assert org.endswith("(chargeback)")
     assert GrowthReporter._scope_label({"a", "b"}, 165, 137) == (
-        "Scoped to 2 selected workspace(s)"
+        "Scoped to 2 selected workspace(s) (per-user totals remain org-wide)"
     )
     assert GrowthReporter._scope_label(None, None, None) == "Org-wide (chargeback)"
 
@@ -1027,7 +1027,7 @@ def test_unified_section_org_overview_from_chargeback():
     growth = next(k for k in section["kpis"] if k["label"].startswith("New in"))
     # alice's team-a created in Jan (in-window), bob's team-b in Feb (in-window),
     # none before the window start -> 0 before -> 0.0%, "+2 new"
-    assert growth["sub"] == "+2 new"
+    assert growth["sub"] == "+2 new (est. from earliest member)"
     ids = [c["id"] for c in section["charts"]]
     # Chargeback charts stay; SDK creation timelines move to per-product sections.
     assert "chart-unified-platform-mix" in ids
@@ -1189,10 +1189,12 @@ def test_scope_label_uses_post_filter_count_not_requested_args():
 
     # three workspaces requested, but only one survives scoping/--exclude-personal
     label = GrowthReporter._scope_label({"a", "b", "c"}, 100, 50, scoped_count=1)
-    assert label == "Scoped to 1 selected workspace(s)"
+    assert label == (
+        "Scoped to 1 selected workspace(s) (per-user totals remain org-wide)"
+    )
     # falls back to len(scope) when no scoped_count is given
     assert GrowthReporter._scope_label({"a", "b"}, 100, 50) == (
-        "Scoped to 2 selected workspace(s)"
+        "Scoped to 2 selected workspace(s) (per-user totals remain org-wide)"
     )
 
 

--- a/tests/unit/test_admin_growth_report.py
+++ b/tests/unit/test_admin_growth_report.py
@@ -214,8 +214,8 @@ def _sample_report_data():
                         "id": "chart-personal-vs-service-experiments",
                         "kind": "groupedBarsH",
                         "title": "Personal vs. service accounts: experiments",
-                        "hint": "Source: heuristic (regex); admin API returned no "
-                        "service accounts.",
+                        "hint": "Source: heuristic (regex); admin "
+                        "service-accounts API unavailable.",
                         "data": {
                             "rows": [
                                 {"label": "Personal", "value": 70},
@@ -1170,6 +1170,49 @@ def test_personal_vs_service_honors_empty_admin_set():
     section = r._build_personal_vs_service_section(parse_users(cb), set())
     assert section is not None
     assert "admin API" in section["charts"][0]["hint"]
+
+
+def test_short_api_error_redacts_header_cookie_body_on_fallback():
+    from cometx.cli.admin_growth_report import _short_api_error
+
+    # No status_code/'message' to parse -> fallback must drop the sensitive tail
+    leaky = (
+        "Connection failed headers: {'set-cookie': 'session=SECRET', "
+        "'content-security-policy': \"base-uri 'self'\"} body: {'token': 'sk-xyz'}"
+    )
+    out = _short_api_error(leaky)
+    assert out == "Connection failed"
+    for bad in ("set-cookie", "SECRET", "content-security-policy", "sk-xyz", "body:"):
+        assert bad not in out
+
+
+def test_personal_vs_service_heuristic_hint_says_unavailable_not_empty():
+    # service_account_names=None means the admin fetch FAILED; the hint must not
+    # imply the admin API returned an empty list.
+    from cometx.cli.admin_growth_report import GrowthReporter
+    from cometx.cli.admin_growth_users import parse_users
+
+    cb = {
+        "workspaces": [],
+        "users": {
+            "report": [
+                {
+                    "username": "alice",
+                    "email": "a",
+                    "experimentCount": 5,
+                    "dataLoggedMb": 2.0,
+                    "lastUsedAt": 1,
+                },
+            ]
+        },
+    }
+    api = MagicMock()
+    r = GrowthReporter(api, window="7d", units="month")
+    section = r._build_personal_vs_service_section(parse_users(cb), None)
+    assert section is not None
+    hint = section["charts"][0]["hint"]
+    assert "unavailable" in hint
+    assert "returned no service accounts" not in hint
 
 
 def test_short_api_error_condenses_verbose_sdk_error():

--- a/tests/unit/test_admin_growth_report.py
+++ b/tests/unit/test_admin_growth_report.py
@@ -2034,3 +2034,20 @@ def test_assemble_report_data_degrades_personal_vs_service_without_crashing(monk
     data = r.build([])  # must not raise
 
     assert "personal_vs_service" not in data["sections"]
+
+
+def test_exclude_personal_filters_by_pattern():
+    from cometx.cli.admin_growth_report import GrowthReporter
+    api = MagicMock()
+    r = GrowthReporter(api, window="7d", units="month", platforms="em",
+                       exclude_personal=True, personal_pattern=r"^user-")
+    kept = r._filter_personal(["team-a", "user-alice", "team-b"])
+    assert kept == ["team-a", "team-b"]
+
+
+def test_exclude_personal_without_pattern_is_noop():
+    from cometx.cli.admin_growth_report import GrowthReporter
+    api = MagicMock()
+    r = GrowthReporter(api, window="7d", units="month", platforms="em",
+                       exclude_personal=True, personal_pattern=None)
+    assert r._filter_personal(["a", "b"]) == ["a", "b"]

--- a/tests/unit/test_admin_growth_report.py
+++ b/tests/unit/test_admin_growth_report.py
@@ -1044,6 +1044,58 @@ def test_unified_section_org_overview_from_chargeback():
     assert section["table"]["title"] == "By workspace (org-wide, chargeback)"
 
 
+def test_unified_churn_rate_uses_net_surviving_base():
+    """The churn growth-rate denominator is the *surviving* total at the start
+    of each bucket, so it must subtract deletions from earlier buckets. If it
+    only accumulated additions the Mar rate below would read 50% (1/2) instead
+    of the correct 100% (1/1, since one of the two Jan workspaces was deleted
+    in Feb)."""
+    from cometx.cli.admin_growth_report import GrowthReporter
+    from cometx.cli.admin_growth_users import parse_users, parse_workspaces
+
+    def _ms(y, mo):
+        return int(
+            datetime.datetime(y, mo, 15, tzinfo=datetime.timezone.utc).timestamp()
+            * 1000
+        )
+
+    jan, feb, mar = _ms(2026, 1), _ms(2026, 2), _ms(2026, 3)
+    now_ms = int(
+        datetime.datetime(2026, 7, 1, tzinfo=datetime.timezone.utc).timestamp() * 1000
+    )
+    cb = {
+        "workspaces": [
+            {"name": "ws-1", "members": [{"userName": "u1"}]},
+            {"name": "ws-2", "members": [{"userName": "u2"}]},
+            {"name": "ws-3", "members": [{"userName": "u3"}]},
+        ],
+        "users": {
+            "licensedUsers": [
+                {"username": "u1", "email": "u1", "createdAt": jan},
+                # u2's workspace is fully deleted in Feb (every member deleted)
+                {"username": "u2", "email": "u2", "createdAt": jan, "deletedAt": feb},
+                {"username": "u3", "email": "u3", "createdAt": mar},
+            ]
+        },
+    }
+    api = MagicMock()
+    r = GrowthReporter(api, window="7d", units="month")
+    section = r._build_unified_section(
+        _win(),
+        people_users=parse_users(cb),
+        ws_records=parse_workspaces(cb),
+        now_ms=now_ms,
+        active_window_days=30,
+    )
+    churn = next(
+        c for c in section["charts"] if c["id"] == "chart-unified-workspace-churn"
+    )
+    by_key = {p["key"]: p["values"] for p in churn["data"]["points"]}
+    # Surviving base at Mar start = 2 added - 1 deleted = 1 -> 1/1 * 100.
+    assert by_key["2026-03"]["added"] == 1
+    assert by_key["2026-03"]["rate"] == 100.0
+
+
 def test_build_raises_when_chargeback_unavailable(monkeypatch):
     import cometx.cli.admin_growth_report as agr
     from cometx.cli.admin_growth_report import GrowthReporter, GrowthReportError

--- a/tests/unit/test_admin_growth_users.py
+++ b/tests/unit/test_admin_growth_users.py
@@ -229,3 +229,205 @@ def test_classify_accounts_regex_matches_sagemaker_domain_anchored():
         _classify_username("dana2", email="dana2@sagemaker-integration.com.evil.com")
         == "personal"
     )
+
+
+def test_classify_accounts_regex_matches_pipeline_and_automated_tokens():
+    # Added to match the client notebook's classifier: "pipeline-" prefix and
+    # the "automated" substring both indicate a service account.
+    assert _classify_username("pipeline-nightly") == "service"
+    assert _classify_username("data-automated-job") == "service"
+    # "automation" does NOT contain "automated" -- must stay personal (guards
+    # against over-matching the new keyword token).
+    assert _classify_username("automation") == "personal"
+
+
+def test_adoption_rate_series_percentages():
+    from cometx.cli.admin_growth_users import adoption_rate_series, parse_users
+
+    pts = adoption_rate_series(
+        parse_users(_cb()), units="month", now_ms=NOW, active_window_days=30
+    )
+    assert pts
+    # Last bucket: non-suspended existing = alice + bob (carol suspended); of
+    # those, only alice is active within 30d overall / on EM / on Opik.
+    last = pts[-1]["values"]
+    assert last["overall"] == 50.0
+    assert last["em"] == 50.0
+    assert last["opik"] == 50.0
+
+
+def test_adoption_rate_series_empty_when_no_created_at():
+    from cometx.cli.admin_growth_users import adoption_rate_series, parse_users
+
+    cb = {
+        "workspaces": [],
+        "users": {
+            "licensedUsers": [{"username": "x", "email": "x", "lastUsedAt": NOW}]
+        },
+    }
+    assert (
+        adoption_rate_series(
+            parse_users(cb), units="month", now_ms=NOW, active_window_days=30
+        )
+        == []
+    )
+
+
+def test_workspace_active_series_total_and_active():
+    from cometx.cli.admin_growth_users import parse_users, workspace_active_series
+
+    pts = workspace_active_series(
+        parse_users(_cb()), units="month", now_ms=NOW, active_window_days=30
+    )
+    assert pts
+    last = pts[-1]["values"]
+    assert last["total"] == 2  # team-a, team-b (from non-suspended alice/bob)
+    assert last["active"] == 2  # active alice belongs to both -> both active
+    # no membership anywhere -> None
+    cb = {
+        "workspaces": [],
+        "users": {
+            "licensedUsers": [
+                {"username": "x", "email": "x", "createdAt": NOW - 1, "lastUsedAt": NOW}
+            ]
+        },
+    }
+    assert (
+        workspace_active_series(
+            parse_users(cb), units="month", now_ms=NOW, active_window_days=30
+        )
+        is None
+    )
+
+
+def test_churn_series_added_and_deleted():
+    from cometx.cli.admin_growth_users import churn_series, parse_users
+
+    month = 30 * 86400 * 1000
+    cb = {
+        "workspaces": [],
+        "users": {
+            "licensedUsers": [
+                {
+                    "username": "a",
+                    "email": "a",
+                    "createdAt": NOW - 3 * month,
+                    "lastUsedAt": NOW,
+                },
+                {
+                    "username": "b",
+                    "email": "b",
+                    "createdAt": NOW - 2 * month,
+                    "lastUsedAt": NOW,
+                    "deletedAt": NOW - month,
+                },
+            ]
+        },
+    }
+    pts = churn_series(parse_users(cb), units="month", now_ms=NOW)
+    assert pts
+    assert sum(p["values"]["added"] for p in pts) == 2
+    assert sum(p["values"]["deleted"] for p in pts) == 1
+
+
+def test_em_user_breakdown_series():
+    from cometx.cli.admin_growth_users import em_user_breakdown_series, parse_users
+
+    last = em_user_breakdown_series(
+        parse_users(_cb()), units="month", now_ms=NOW, active_window_days=30
+    )[-1]["values"]
+    assert last["experimenters"] == 2  # alice(40) + bob(1)
+    assert last["data_pushers"] == 2  # alice(100) + bob(2)
+    assert last["active"] == 1  # only alice has emLastUsedAt in window
+
+
+def test_opik_user_breakdown_series():
+    from cometx.cli.admin_growth_users import opik_user_breakdown_series, parse_users
+
+    last = opik_user_breakdown_series(
+        parse_users(_cb()), units="month", now_ms=NOW, active_window_days=30
+    )[-1]["values"]
+    assert last["span_producers"] == 1  # only alice has opikSpanCount > 0
+    assert last["active"] == 1  # only alice has opikLastUsedAt in window
+
+
+def test_workspace_churn_series_added():
+    from cometx.cli.admin_growth_users import parse_users, workspace_churn_series
+
+    pts = workspace_churn_series(parse_users(_cb()), units="month", now_ms=NOW)
+    assert pts
+    assert sum(p["values"]["added"] for p in pts) == 2  # team-a, team-b
+    assert sum(p["values"]["deleted"] for p in pts) == 0  # no fully-deleted workspace
+
+
+def test_workspace_active_stats():
+    from cometx.cli.admin_growth_users import parse_users, workspace_active_stats
+
+    stats = workspace_active_stats(
+        parse_users(_cb()), now_ms=NOW, active_window_days=30
+    )
+    # team-a (alice/bob) + team-b (alice); carol suspended contributes nothing
+    assert stats["total"] == 2
+    # alice active covers both workspaces; bob inactive but alice keeps both active
+    assert stats["active"] == 2
+    assert stats["active_pct"] == 100.0
+
+
+def test_parse_workspaces_org_totals_and_platform_mix():
+    from cometx.cli.admin_growth_users import (
+        parse_users,
+        parse_workspaces,
+        platform_mix,
+        workspace_org_totals,
+    )
+
+    cb = {
+        "workspaces": [
+            {
+                "name": "em-ws",
+                "numberOfExperiments": 10,
+                "totalSizeInMb": 5.0,
+                "projects": [{}, {}],
+                "members": [{"userName": "a"}],
+            },
+            {
+                "name": "opik-ws",
+                "numberOfExperiments": 0,
+                "projects": [],
+                "members": [{"userName": "b"}],
+            },
+            {
+                "name": "both-ws",
+                "numberOfExperiments": 3,
+                "projects": [{}],
+                "members": [{"userName": "c"}],
+            },
+            {
+                "name": "empty-ws",
+                "numberOfExperiments": 0,
+                "projects": [],
+                "members": [],
+            },
+        ],
+        "users": {
+            "licensedUsers": [
+                {"username": "a", "email": "a", "opikSpanCount": 0, "lastUsedAt": 1},
+                {"username": "b", "email": "b", "opikSpanCount": 500, "lastUsedAt": 1},
+                {"username": "c", "email": "c", "opikSpanCount": 50, "lastUsedAt": 1},
+            ]
+        },
+    }
+    ws = parse_workspaces(cb)
+    assert workspace_org_totals(ws) == {
+        "workspaces": 4,
+        "projects": 3,
+        "experiments": 13,
+        "data_mb": 5.0,
+    }
+    # em-ws=EM only; opik-ws=Opik only (b has spans); both-ws=both; empty-ws=neither
+    assert platform_mix(ws, parse_users(cb)) == {
+        "em_only": 1,
+        "opik_only": 1,
+        "both": 1,
+        "neither": 1,
+    }

--- a/tests/unit/test_admin_growth_users.py
+++ b/tests/unit/test_admin_growth_users.py
@@ -200,6 +200,54 @@ def test_series_share_bucket_start_with_churn_when_earliest_is_suspended():
     assert active[-1]["values"]["total"] == 1
 
 
+def test_workspace_active_series_still_charts_when_no_user_is_dated():
+    # When no user carries a createdAt there is no timeline, but the KPI
+    # (workspace_active_stats) still reports a total/active from membership.
+    # The series must emit a single "as of now" bucket agreeing with that KPI
+    # rather than [] -- an empty list makes the caller drop the chart while its
+    # KPI shows real numbers.
+    from cometx.cli.admin_growth_users import (
+        parse_users,
+        parse_workspaces,
+        workspace_active_series,
+        workspace_active_stats,
+    )
+
+    cb = {
+        "workspaces": [
+            {"name": "team-a", "members": [{"userName": "alice"}]},
+            {"name": "team-b", "members": []},
+        ],
+        "users": {
+            "licensedUsers": [
+                {
+                    "username": "alice",
+                    "email": "a@x",
+                    "createdAt": None,
+                    "lastUsedAt": NOW,
+                    "deletedAt": None,
+                    "suspended": False,
+                }
+            ]
+        },
+    }
+    users = parse_users(cb)
+    all_ws = {w.name for w in parse_workspaces(cb)}
+    pts = workspace_active_series(
+        users,
+        units="month",
+        now_ms=NOW,
+        active_window_days=30,
+        all_workspaces=all_ws,
+    )
+    stats = workspace_active_stats(
+        users, now_ms=NOW, active_window_days=30, all_workspaces=all_ws
+    )
+    assert pts, "chart must not be dropped while its KPI reports numbers"
+    assert pts[-1]["values"]["total"] == stats["total"] == 2
+    assert pts[-1]["values"]["active"] == stats["active"] == 1
+
+
 def test_capability_series_none_when_no_capability_fields():
     from cometx.cli.admin_growth_users import capability_series, parse_users
 

--- a/tests/unit/test_admin_growth_users.py
+++ b/tests/unit/test_admin_growth_users.py
@@ -248,6 +248,60 @@ def test_workspace_active_series_still_charts_when_no_user_is_dated():
     assert pts[-1]["values"]["active"] == stats["active"] == 1
 
 
+def test_undated_fallback_total_matches_kpi_for_all_suspended_workspace():
+    # A workspace whose only members are suspended is absent from both the
+    # membership reverse-map subset and the seeded set, yet still counts toward
+    # the KPI's all_workspaces denominator. The fallback bucket's `total` must
+    # follow the KPI, not the membership subset.
+    from cometx.cli.admin_growth_users import (
+        parse_users,
+        parse_workspaces,
+        workspace_active_series,
+        workspace_active_stats,
+    )
+
+    cb = {
+        "workspaces": [
+            {"name": "team-a", "members": [{"userName": "alice"}]},
+            {"name": "team-b", "members": [{"userName": "zed"}]},
+        ],
+        "users": {
+            "licensedUsers": [
+                {
+                    "username": "alice",
+                    "email": "a@x",
+                    "createdAt": None,
+                    "lastUsedAt": NOW,
+                    "deletedAt": None,
+                    "suspended": False,
+                },
+                {
+                    "username": "zed",
+                    "email": "z@x",
+                    "createdAt": None,
+                    "lastUsedAt": NOW,
+                    "deletedAt": None,
+                    "suspended": True,  # team-b's only member
+                },
+            ]
+        },
+    }
+    users = parse_users(cb)
+    all_ws = {w.name for w in parse_workspaces(cb)}
+    pts = workspace_active_series(
+        users,
+        units="month",
+        now_ms=NOW,
+        active_window_days=30,
+        all_workspaces=all_ws,
+    )
+    stats = workspace_active_stats(
+        users, now_ms=NOW, active_window_days=30, all_workspaces=all_ws
+    )
+    assert pts[-1]["values"]["total"] == stats["total"] == 2
+    assert pts[-1]["values"]["active"] == stats["active"] == 1
+
+
 def test_capability_series_none_when_no_capability_fields():
     from cometx.cli.admin_growth_users import capability_series, parse_users
 

--- a/tests/unit/test_admin_growth_users.py
+++ b/tests/unit/test_admin_growth_users.py
@@ -79,3 +79,23 @@ def test_capability_series_none_when_no_capability_fields():
     cb = {"workspaces": [], "users": {"licensedUsers": [
         {"username": "x", "email": "x", "lastUsedAt": NOW, "createdAt": NOW - 1}]}}
     assert capability_series(parse_users(cb), units="month", now_ms=NOW, active_window_days=30) is None
+
+
+def test_classify_accounts_uses_service_account_set():
+    from cometx.cli.admin_growth_users import parse_users, classify_accounts
+    users = parse_users(_cb())
+    out = classify_accounts(users, service_account_names={"bob"})
+    assert out["service"]["experiments"] == 1   # bob
+    assert out["personal"]["experiments"] == 40  # alice (carol suspended still counts data? no: include all non-deleted)
+
+
+def test_classify_accounts_regex_fallback_labeled():
+    from cometx.cli.admin_growth_users import parse_users, classify_accounts
+    cb = {"workspaces": [], "users": {"licensedUsers": [
+        {"username": "svc-pipeline", "email": "p@x", "experimentCount": 3, "lastUsedAt": 1},
+        {"username": "dana", "email": "d@x", "experimentCount": 7, "lastUsedAt": 1}]}}
+    users = parse_users(cb)
+    out = classify_accounts(users, service_account_names=None)
+    assert out["service"]["experiments"] == 3
+    assert out["personal"]["experiments"] == 7
+    assert out["source"] == "heuristic"

--- a/tests/unit/test_admin_growth_users.py
+++ b/tests/unit/test_admin_growth_users.py
@@ -431,3 +431,38 @@ def test_parse_workspaces_org_totals_and_platform_mix():
         "both": 1,
         "neither": 1,
     }
+
+
+def test_workspace_active_series_seeds_all_workspaces_incl_zero_member():
+    # A workspace with zero datable members never appears in the membership
+    # reverse-map, but seeding from all_workspaces keeps `total` aligned with
+    # the KPI (workspace_active_stats(..., all_workspaces=...)).
+    from cometx.cli.admin_growth_users import parse_users, workspace_active_series
+
+    now = 1_720_000_000_000
+    cb = {
+        "workspaces": [
+            {"name": "ws-a", "members": [{"userName": "alice"}]},
+            {"name": "ws-empty", "members": []},  # zero members -> not in reverse-map
+        ],
+        "users": {
+            "report": [
+                {
+                    "username": "alice",
+                    "email": "a",
+                    "createdAt": now - 10**10,
+                    "lastUsedAt": now,
+                },
+            ]
+        },
+    }
+    users = parse_users(cb)
+    pts = workspace_active_series(
+        users, "month", now, 60, all_workspaces={"ws-a", "ws-empty"}
+    )
+    assert pts is not None
+    # every bucket's total includes the zero-member workspace (seeded = 2)
+    assert all(p["values"]["total"] == 2 for p in pts)
+    # without the seed, ws-empty would be missing -> total 1
+    pts_noseed = workspace_active_series(users, "month", now, 60)
+    assert all(p["values"]["total"] == 1 for p in pts_noseed)

--- a/tests/unit/test_admin_growth_users.py
+++ b/tests/unit/test_admin_growth_users.py
@@ -63,3 +63,19 @@ def test_top_users_absent_span_field_excluded():
     users = parse_users(cb)
     assert users[0].opik_span_count is None
     assert top_users(users, key="opik_span_count", n=5) == []  # nothing has the metric
+
+
+def test_active_series_buckets_total_and_active():
+    from cometx.cli.admin_growth_users import parse_users, active_series
+    users = parse_users(_cb())
+    pts = active_series(users, units="month", now_ms=NOW, active_window_days=30)
+    assert pts and all("total" in p["values"] and "active" in p["values"] for p in pts)
+    # last bucket total excludes suspended carol
+    assert pts[-1]["values"]["total"] == 2
+
+
+def test_capability_series_none_when_no_capability_fields():
+    from cometx.cli.admin_growth_users import parse_users, capability_series
+    cb = {"workspaces": [], "users": {"licensedUsers": [
+        {"username": "x", "email": "x", "lastUsedAt": NOW, "createdAt": NOW - 1}]}}
+    assert capability_series(parse_users(cb), units="month", now_ms=NOW, active_window_days=30) is None

--- a/tests/unit/test_admin_growth_users.py
+++ b/tests/unit/test_admin_growth_users.py
@@ -99,3 +99,33 @@ def test_classify_accounts_regex_fallback_labeled():
     assert out["service"]["experiments"] == 3
     assert out["personal"]["experiments"] == 7
     assert out["source"] == "heuristic"
+
+
+def _classify_username(username, email=None):
+    """Helper: classify a single synthetic user (heuristic path) and return
+    "personal" or "service"."""
+    from cometx.cli.admin_growth_users import parse_users, classify_accounts
+    cb = {"workspaces": [], "users": {"licensedUsers": [
+        {"username": username, "email": email or (username + "@x.com"),
+         "experimentCount": 1, "lastUsedAt": 1}]}}
+    users = parse_users(cb)
+    out = classify_accounts(users, service_account_names=None)
+    return "service" if out["service"]["experiments"] == 1 else "personal"
+
+
+def test_classify_accounts_regex_does_not_mislabel_substring_matches():
+    # "lisa-brown" contains "sa-"; "abbot-jones" contains "bot-". Neither is
+    # a service-account naming convention -- both are plain personal users.
+    assert _classify_username("lisa-brown") == "personal"
+    assert _classify_username("abbot-jones") == "personal"
+
+
+def test_classify_accounts_regex_matches_anchored_prefix_tokens():
+    assert _classify_username("sa-pipeline") == "service"
+    assert _classify_username("svc-x") == "service"
+    assert _classify_username("bot-runner") == "service"
+
+
+def test_classify_accounts_regex_matches_sagemaker_domain_anchored():
+    assert _classify_username("dana", email="dana@sagemaker-integration.com") == "service"
+    assert _classify_username("dana2", email="dana2@sagemaker-integration.com.evil.com") == "personal"

--- a/tests/unit/test_admin_growth_users.py
+++ b/tests/unit/test_admin_growth_users.py
@@ -159,6 +159,47 @@ def test_active_series_sweep_drops_user_after_deletion():
     assert totals[-1] == 1
 
 
+def test_series_share_bucket_start_with_churn_when_earliest_is_suspended():
+    # The _iter_buckets sweep must span every dated user, suspended included,
+    # so the bucket-based series keep the same x-axis start as churn_series
+    # (which reads created_at/deleted_at directly and can't skip suspended
+    # accounts). The suspended user is still absent from `existing`, so the
+    # leading buckets read zero rather than being dropped from the chart.
+    from cometx.cli.admin_growth_users import active_series, churn_series, parse_users
+
+    month = 31 * 86400 * 1000
+    cb = {
+        "workspaces": [],
+        "users": {
+            "licensedUsers": [
+                {
+                    "username": "old-suspended",
+                    "email": "o@x",
+                    "createdAt": NOW - 6 * month,
+                    "lastUsedAt": None,
+                    "deletedAt": None,
+                    "suspended": True,
+                },
+                {
+                    "username": "recent",
+                    "email": "r@x",
+                    "createdAt": NOW - 2 * month,
+                    "lastUsedAt": NOW,
+                    "deletedAt": None,
+                    "suspended": False,
+                },
+            ]
+        },
+    }
+    users = parse_users(cb)
+    active = active_series(users, units="month", now_ms=NOW, active_window_days=30)
+    churn = churn_series(users, units="month", now_ms=NOW)
+    assert [p["key"] for p in active] == [p["key"] for p in churn]
+    # the suspended account never counts toward `total`, so early buckets are 0
+    assert active[0]["values"]["total"] == 0
+    assert active[-1]["values"]["total"] == 1
+
+
 def test_capability_series_none_when_no_capability_fields():
     from cometx.cli.admin_growth_users import capability_series, parse_users
 

--- a/tests/unit/test_admin_growth_users.py
+++ b/tests/unit/test_admin_growth_users.py
@@ -117,6 +117,48 @@ def test_active_series_buckets_total_and_active():
     assert pts[-1]["values"]["total"] == 2
 
 
+def test_active_series_sweep_drops_user_after_deletion():
+    # Guards the _iter_buckets sweep refactor: a user created early and
+    # deleted mid-span must be counted in buckets before their deletion and
+    # excluded from buckets after it (the anti-monotone deletion case the
+    # created-sorted sweep pointer must still honor).
+    from cometx.cli.admin_growth_users import active_series, parse_users
+
+    month = 31 * 86400 * 1000
+    start = NOW - 4 * month
+    cb = {
+        "workspaces": [],
+        "users": {
+            "licensedUsers": [
+                {
+                    "username": "steady",
+                    "email": "s@x",
+                    "createdAt": start,
+                    "lastUsedAt": NOW,
+                    "deletedAt": None,
+                    "suspended": False,
+                },
+                {
+                    "username": "leaver",
+                    "email": "l@x",
+                    "createdAt": start,
+                    "lastUsedAt": NOW - 3 * month,
+                    # deleted ~2 months before now
+                    "deletedAt": NOW - 2 * month,
+                    "suspended": False,
+                },
+            ]
+        },
+    }
+    pts = active_series(
+        parse_users(cb), units="month", now_ms=NOW, active_window_days=30
+    )
+    totals = [p["values"]["total"] for p in pts]
+    # both present in the first bucket; only 'steady' survives to the last
+    assert totals[0] == 2
+    assert totals[-1] == 1
+
+
 def test_capability_series_none_when_no_capability_fields():
     from cometx.cli.admin_growth_users import capability_series, parse_users
 

--- a/tests/unit/test_admin_growth_users.py
+++ b/tests/unit/test_admin_growth_users.py
@@ -12,23 +12,51 @@ def _cb():
             {"name": "team-a", "members": [{"userName": "alice"}, {"userName": "bob"}]},
             {"name": "team-b", "members": [{"userName": "alice"}]},
         ],
-        "users": {"licensedUsers": [
-            {"username": "alice", "email": "a@x.com", "createdAt": NOW - 100,
-             "lastUsedAt": NOW - 10, "experimentCount": 40, "dataLoggedMb": 100.0,
-             "opikSpanCount": 5000, "emLastUsedAt": NOW - 10, "opikLastUsedAt": NOW - 10,
-             "suspended": False, "deletedAt": None},
-            {"username": "bob", "email": "b@x.com", "createdAt": NOW - 100,
-             "lastUsedAt": NOW - (60 * 86400 * 1000), "experimentCount": 1,
-             "dataLoggedMb": 2.0, "opikSpanCount": 0, "suspended": False, "deletedAt": None},
-            {"username": "carol", "email": "c@x.com", "createdAt": NOW - 100,
-             "lastUsedAt": NOW - 5, "experimentCount": 0, "dataLoggedMb": 0.0,
-             "opikSpanCount": 0, "suspended": True, "deletedAt": None},
-        ]},
+        "users": {
+            "licensedUsers": [
+                {
+                    "username": "alice",
+                    "email": "a@x.com",
+                    "createdAt": NOW - 100,
+                    "lastUsedAt": NOW - 10,
+                    "experimentCount": 40,
+                    "dataLoggedMb": 100.0,
+                    "opikSpanCount": 5000,
+                    "emLastUsedAt": NOW - 10,
+                    "opikLastUsedAt": NOW - 10,
+                    "suspended": False,
+                    "deletedAt": None,
+                },
+                {
+                    "username": "bob",
+                    "email": "b@x.com",
+                    "createdAt": NOW - 100,
+                    "lastUsedAt": NOW - (60 * 86400 * 1000),
+                    "experimentCount": 1,
+                    "dataLoggedMb": 2.0,
+                    "opikSpanCount": 0,
+                    "suspended": False,
+                    "deletedAt": None,
+                },
+                {
+                    "username": "carol",
+                    "email": "c@x.com",
+                    "createdAt": NOW - 100,
+                    "lastUsedAt": NOW - 5,
+                    "experimentCount": 0,
+                    "dataLoggedMb": 0.0,
+                    "opikSpanCount": 0,
+                    "suspended": True,
+                    "deletedAt": None,
+                },
+            ]
+        },
     }
 
 
 def test_parse_users_maps_workspaces_and_fields():
     from cometx.cli.admin_growth_users import parse_users
+
     users = {u.username: u for u in parse_users(_cb())}
     assert set(users["alice"].workspaces) == {"team-a", "team-b"}
     assert users["alice"].opik_span_count == 5000
@@ -36,7 +64,8 @@ def test_parse_users_maps_workspaces_and_fields():
 
 
 def test_adoption_excludes_suspended_and_respects_window():
-    from cometx.cli.admin_growth_users import parse_users, adoption_stats
+    from cometx.cli.admin_growth_users import adoption_stats, parse_users
+
     users = parse_users(_cb())
     stats = adoption_stats(users, now_ms=NOW, active_window_days=30)
     # total = alice + bob (carol suspended, excluded); active = alice only (bob 60d ago)
@@ -46,7 +75,8 @@ def test_adoption_excludes_suspended_and_respects_window():
 
 
 def test_top_and_bottom_users_by_em_score():
-    from cometx.cli.admin_growth_users import parse_users, top_users, bottom_users
+    from cometx.cli.admin_growth_users import bottom_users, parse_users, top_users
+
     users = parse_users(_cb())
     top = top_users(users, key="em_score", n=1)
     assert top[0].username == "alice"
@@ -57,16 +87,29 @@ def test_top_and_bottom_users_by_em_score():
 
 def test_top_users_absent_span_field_excluded():
     from cometx.cli.admin_growth_users import parse_users, top_users
+
     # a report with NO opikSpanCount anywhere
-    cb = {"workspaces": [], "users": {"licensedUsers": [
-        {"username": "x", "email": "x@x", "lastUsedAt": NOW, "experimentCount": 1}]}}
+    cb = {
+        "workspaces": [],
+        "users": {
+            "licensedUsers": [
+                {
+                    "username": "x",
+                    "email": "x@x",
+                    "lastUsedAt": NOW,
+                    "experimentCount": 1,
+                }
+            ]
+        },
+    }
     users = parse_users(cb)
     assert users[0].opik_span_count is None
     assert top_users(users, key="opik_span_count", n=5) == []  # nothing has the metric
 
 
 def test_active_series_buckets_total_and_active():
-    from cometx.cli.admin_growth_users import parse_users, active_series
+    from cometx.cli.admin_growth_users import active_series, parse_users
+
     users = parse_users(_cb())
     pts = active_series(users, units="month", now_ms=NOW, active_window_days=30)
     assert pts and all("total" in p["values"] and "active" in p["values"] for p in pts)
@@ -75,25 +118,57 @@ def test_active_series_buckets_total_and_active():
 
 
 def test_capability_series_none_when_no_capability_fields():
-    from cometx.cli.admin_growth_users import parse_users, capability_series
-    cb = {"workspaces": [], "users": {"licensedUsers": [
-        {"username": "x", "email": "x", "lastUsedAt": NOW, "createdAt": NOW - 1}]}}
-    assert capability_series(parse_users(cb), units="month", now_ms=NOW, active_window_days=30) is None
+    from cometx.cli.admin_growth_users import capability_series, parse_users
+
+    cb = {
+        "workspaces": [],
+        "users": {
+            "licensedUsers": [
+                {"username": "x", "email": "x", "lastUsedAt": NOW, "createdAt": NOW - 1}
+            ]
+        },
+    }
+    assert (
+        capability_series(
+            parse_users(cb), units="month", now_ms=NOW, active_window_days=30
+        )
+        is None
+    )
 
 
 def test_classify_accounts_uses_service_account_set():
-    from cometx.cli.admin_growth_users import parse_users, classify_accounts
+    from cometx.cli.admin_growth_users import classify_accounts, parse_users
+
     users = parse_users(_cb())
     out = classify_accounts(users, service_account_names={"bob"})
-    assert out["service"]["experiments"] == 1   # bob
-    assert out["personal"]["experiments"] == 40  # alice (carol suspended still counts data? no: include all non-deleted)
+    assert out["service"]["experiments"] == 1  # bob
+    assert (
+        out["personal"]["experiments"] == 40
+    )  # alice (carol suspended still counts data? no: include all non-deleted)
 
 
 def test_classify_accounts_regex_fallback_labeled():
-    from cometx.cli.admin_growth_users import parse_users, classify_accounts
-    cb = {"workspaces": [], "users": {"licensedUsers": [
-        {"username": "svc-pipeline", "email": "p@x", "experimentCount": 3, "lastUsedAt": 1},
-        {"username": "dana", "email": "d@x", "experimentCount": 7, "lastUsedAt": 1}]}}
+    from cometx.cli.admin_growth_users import classify_accounts, parse_users
+
+    cb = {
+        "workspaces": [],
+        "users": {
+            "licensedUsers": [
+                {
+                    "username": "svc-pipeline",
+                    "email": "p@x",
+                    "experimentCount": 3,
+                    "lastUsedAt": 1,
+                },
+                {
+                    "username": "dana",
+                    "email": "d@x",
+                    "experimentCount": 7,
+                    "lastUsedAt": 1,
+                },
+            ]
+        },
+    }
     users = parse_users(cb)
     out = classify_accounts(users, service_account_names=None)
     assert out["service"]["experiments"] == 3
@@ -104,10 +179,21 @@ def test_classify_accounts_regex_fallback_labeled():
 def _classify_username(username, email=None):
     """Helper: classify a single synthetic user (heuristic path) and return
     "personal" or "service"."""
-    from cometx.cli.admin_growth_users import parse_users, classify_accounts
-    cb = {"workspaces": [], "users": {"licensedUsers": [
-        {"username": username, "email": email or (username + "@x.com"),
-         "experimentCount": 1, "lastUsedAt": 1}]}}
+    from cometx.cli.admin_growth_users import classify_accounts, parse_users
+
+    cb = {
+        "workspaces": [],
+        "users": {
+            "licensedUsers": [
+                {
+                    "username": username,
+                    "email": email or (username + "@x.com"),
+                    "experimentCount": 1,
+                    "lastUsedAt": 1,
+                }
+            ]
+        },
+    }
     users = parse_users(cb)
     out = classify_accounts(users, service_account_names=None)
     return "service" if out["service"]["experiments"] == 1 else "personal"
@@ -127,5 +213,10 @@ def test_classify_accounts_regex_matches_anchored_prefix_tokens():
 
 
 def test_classify_accounts_regex_matches_sagemaker_domain_anchored():
-    assert _classify_username("dana", email="dana@sagemaker-integration.com") == "service"
-    assert _classify_username("dana2", email="dana2@sagemaker-integration.com.evil.com") == "personal"
+    assert (
+        _classify_username("dana", email="dana@sagemaker-integration.com") == "service"
+    )
+    assert (
+        _classify_username("dana2", email="dana2@sagemaker-integration.com.evil.com")
+        == "personal"
+    )

--- a/tests/unit/test_admin_growth_users.py
+++ b/tests/unit/test_admin_growth_users.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Unit tests for cometx.cli.admin_growth_users (people layer parse +
+adoption/leaderboard derivations)."""
+
+NOW = 1_720_000_000_000  # fixed ms; ~2024-07, tests pass now_ms explicitly
+
+
+def _cb():
+    return {
+        "workspaces": [
+            {"name": "team-a", "members": [{"userName": "alice"}, {"userName": "bob"}]},
+            {"name": "team-b", "members": [{"userName": "alice"}]},
+        ],
+        "users": {"licensedUsers": [
+            {"username": "alice", "email": "a@x.com", "createdAt": NOW - 100,
+             "lastUsedAt": NOW - 10, "experimentCount": 40, "dataLoggedMb": 100.0,
+             "opikSpanCount": 5000, "emLastUsedAt": NOW - 10, "opikLastUsedAt": NOW - 10,
+             "suspended": False, "deletedAt": None},
+            {"username": "bob", "email": "b@x.com", "createdAt": NOW - 100,
+             "lastUsedAt": NOW - (60 * 86400 * 1000), "experimentCount": 1,
+             "dataLoggedMb": 2.0, "opikSpanCount": 0, "suspended": False, "deletedAt": None},
+            {"username": "carol", "email": "c@x.com", "createdAt": NOW - 100,
+             "lastUsedAt": NOW - 5, "experimentCount": 0, "dataLoggedMb": 0.0,
+             "opikSpanCount": 0, "suspended": True, "deletedAt": None},
+        ]},
+    }
+
+
+def test_parse_users_maps_workspaces_and_fields():
+    from cometx.cli.admin_growth_users import parse_users
+    users = {u.username: u for u in parse_users(_cb())}
+    assert set(users["alice"].workspaces) == {"team-a", "team-b"}
+    assert users["alice"].opik_span_count == 5000
+    assert users["bob"].opik_last_used_at is None  # absent field -> None
+
+
+def test_adoption_excludes_suspended_and_respects_window():
+    from cometx.cli.admin_growth_users import parse_users, adoption_stats
+    users = parse_users(_cb())
+    stats = adoption_stats(users, now_ms=NOW, active_window_days=30)
+    # total = alice + bob (carol suspended, excluded); active = alice only (bob 60d ago)
+    assert stats["total"] == 2
+    assert stats["active"] == 1
+    assert stats["adoption_pct"] == 50.0
+
+
+def test_top_and_bottom_users_by_em_score():
+    from cometx.cli.admin_growth_users import parse_users, top_users, bottom_users
+    users = parse_users(_cb())
+    top = top_users(users, key="em_score", n=1)
+    assert top[0].username == "alice"
+    # bottom = active-aware: only users with em_score > 0, ascending -> bob before alice
+    bot = bottom_users(users, key="em_score", n=1)
+    assert bot[0].username == "bob"
+
+
+def test_top_users_absent_span_field_excluded():
+    from cometx.cli.admin_growth_users import parse_users, top_users
+    # a report with NO opikSpanCount anywhere
+    cb = {"workspaces": [], "users": {"licensedUsers": [
+        {"username": "x", "email": "x@x", "lastUsedAt": NOW, "experimentCount": 1}]}}
+    users = parse_users(cb)
+    assert users[0].opik_span_count is None
+    assert top_users(users, key="opik_span_count", n=5) == []  # nothing has the metric

--- a/tests/unit/test_admin_growth_users.py
+++ b/tests/unit/test_admin_growth_users.py
@@ -466,3 +466,99 @@ def test_workspace_active_series_seeds_all_workspaces_incl_zero_member():
     # without the seed, ws-empty would be missing -> total 1
     pts_noseed = workspace_active_series(users, "month", now, 60)
     assert all(p["values"]["total"] == 1 for p in pts_noseed)
+
+
+def test_top_users_em_score_tolerates_null_counts():
+    # A present-but-null experimentCount/dataLoggedMb must not raise (would
+    # otherwise blank the whole Users + Leaderboards sections).
+    from cometx.cli.admin_growth_users import parse_users, top_users
+
+    cb = {
+        "workspaces": [],
+        "users": {
+            "report": [
+                {
+                    "username": "a",
+                    "email": "a",
+                    "experimentCount": None,
+                    "dataLoggedMb": None,
+                    "lastUsedAt": 1,
+                },
+                {
+                    "username": "b",
+                    "email": "b",
+                    "experimentCount": 5,
+                    "dataLoggedMb": 2.0,
+                    "lastUsedAt": 1,
+                },
+            ]
+        },
+    }
+    top = top_users(parse_users(cb), "em_score", 5)
+    # b (score 7) ranks; a (nulls -> 0) is not > 0 for bottom but top includes it
+    assert [u.username for u in top][0] == "b"
+
+
+def test_leaderboards_exclude_deleted_and_suspended():
+    from cometx.cli.admin_growth_users import bottom_users, parse_users, top_users
+
+    cb = {
+        "workspaces": [],
+        "users": {
+            "report": [
+                {
+                    "username": "live",
+                    "email": "l",
+                    "experimentCount": 10,
+                    "dataLoggedMb": 0.0,
+                    "lastUsedAt": 1,
+                },
+                {
+                    "username": "gone",
+                    "email": "g",
+                    "experimentCount": 999,
+                    "dataLoggedMb": 0.0,
+                    "lastUsedAt": 1,
+                    "deletedAt": 123,
+                },
+                {
+                    "username": "susp",
+                    "email": "s",
+                    "experimentCount": 500,
+                    "dataLoggedMb": 0.0,
+                    "lastUsedAt": 1,
+                    "suspended": True,
+                },
+            ]
+        },
+    }
+    users = parse_users(cb)
+    names = [u.username for u in top_users(users, "em_score", 5)]
+    assert names == ["live"]  # deleted + suspended excluded despite higher scores
+    assert [u.username for u in bottom_users(users, "em_score", 5)] == ["live"]
+
+
+def test_adoption_rate_series_omits_capability_without_signal():
+    from cometx.cli.admin_growth_users import adoption_rate_series, parse_users
+
+    now = 1_720_000_000_000
+    # users have lastUsedAt (overall) + emLastUsedAt, but NO opikLastUsedAt
+    cb = {
+        "workspaces": [],
+        "users": {
+            "report": [
+                {
+                    "username": "a",
+                    "email": "a",
+                    "createdAt": now - 10**10,
+                    "lastUsedAt": now,
+                    "emLastUsedAt": now,
+                },
+            ]
+        },
+    }
+    pts = adoption_rate_series(parse_users(cb), "month", now, 60)
+    assert pts
+    keys = pts[0]["values"].keys()
+    assert "overall" in keys and "em" in keys
+    assert "opik" not in keys  # no opik signal -> omitted, not a flat 0%

--- a/tests/unit/test_admin_growth_users.py
+++ b/tests/unit/test_admin_growth_users.py
@@ -206,6 +206,15 @@ def test_classify_accounts_regex_does_not_mislabel_substring_matches():
     assert _classify_username("abbot-jones") == "personal"
 
 
+def test_classify_accounts_regex_segment_boundary():
+    # "jane-service-accountant" merely CONTAINS the "-service-account"
+    # segment mid-word (as a prefix of "accountant") -- must not be
+    # mislabeled as a service account. "foo-service-account" is the real
+    # naming convention and must still classify as service.
+    assert _classify_username("jane-service-accountant") == "personal"
+    assert _classify_username("foo-service-account") == "service"
+
+
 def test_classify_accounts_regex_matches_anchored_prefix_tokens():
     assert _classify_username("sa-pipeline") == "service"
     assert _classify_username("svc-x") == "service"

--- a/tests/unit/test_migrate_users.py
+++ b/tests/unit/test_migrate_users.py
@@ -47,9 +47,25 @@ class TestResolveServerUrl:
             == "https://example.com"
         )
 
-    def test_explicit_url_non_https_exits(self):
+    def test_explicit_url_allows_http_on_prem(self):
+        # On-prem Comet servers are reached over plain http, and admin_api_url /
+        # _RequestsClient.get both accept it -- --url must not be stricter.
+        assert (
+            _resolve_server_url("anykey", "http://comet.internal.corp")
+            == "http://comet.internal.corp"
+        )
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "ftp://example.com",  # non-http(s) scheme
+            "example.com",  # no scheme/netloc
+            "https://",  # empty netloc
+        ],
+    )
+    def test_explicit_url_malformed_exits(self, url):
         with pytest.raises(SystemExit):
-            _resolve_server_url("anykey", "http://example.com")
+            _resolve_server_url("anykey", url)
 
     def test_new_style_key_decoded(self):
         key = _make_new_style_key("https://self-hosted.example.com")

--- a/tests/unit/test_migrate_users.py
+++ b/tests/unit/test_migrate_users.py
@@ -36,10 +36,16 @@ def _make_new_style_key(base_url):
 class TestResolveServerUrl:
     def test_explicit_url_takes_priority(self):
         key = _make_new_style_key("https://encoded.example.com")
-        assert _resolve_server_url(key, "https://explicit.example.com") == "https://explicit.example.com"
+        assert (
+            _resolve_server_url(key, "https://explicit.example.com")
+            == "https://explicit.example.com"
+        )
 
     def test_explicit_url_trailing_slash_stripped(self):
-        assert _resolve_server_url("anykey", "https://example.com/") == "https://example.com"
+        assert (
+            _resolve_server_url("anykey", "https://example.com/")
+            == "https://example.com"
+        )
 
     def test_explicit_url_non_https_exits(self):
         with pytest.raises(SystemExit):
@@ -105,7 +111,9 @@ class TestAddMember:
     @patch("cometx.cli.migrate_users.requests.post")
     def test_success(self, mock_post):
         mock_post.return_value.status_code = 200
-        status, error = _add_member("http://example.com/add", {}, "user@example.com", "ws1")
+        status, error = _add_member(
+            "http://example.com/add", {}, "user@example.com", "ws1"
+        )
         assert status == "added"
         assert error is None
 
@@ -113,7 +121,9 @@ class TestAddMember:
     def test_already_member(self, mock_post):
         mock_post.return_value.status_code = 400
         mock_post.return_value.json.return_value = {"msg": "already member of ws1"}
-        status, error = _add_member("http://example.com/add", {}, "user@example.com", "ws1")
+        status, error = _add_member(
+            "http://example.com/add", {}, "user@example.com", "ws1"
+        )
         assert status == "already_member"
         assert error is None
 
@@ -121,15 +131,20 @@ class TestAddMember:
     def test_failure(self, mock_post):
         mock_post.return_value.status_code = 403
         mock_post.return_value.json.return_value = {"msg": "forbidden"}
-        status, error = _add_member("http://example.com/add", {}, "user@example.com", "ws1")
+        status, error = _add_member(
+            "http://example.com/add", {}, "user@example.com", "ws1"
+        )
         assert status == "failed"
         assert error["status"] == 403
 
     @patch("cometx.cli.migrate_users.requests.post")
     def test_request_exception(self, mock_post):
         import requests as req
+
         mock_post.side_effect = req.exceptions.ConnectionError("timeout")
-        status, error = _add_member("http://example.com/add", {}, "user@example.com", "ws1")
+        status, error = _add_member(
+            "http://example.com/add", {}, "user@example.com", "ws1"
+        )
         assert status == "failed"
         assert error["status"] == "exception"
 
@@ -149,7 +164,10 @@ class TestMigrateUsersDryRun:
         defaults.update(kwargs)
         return argparse.Namespace(**defaults)
 
-    @patch("cometx.cli.migrate_users._resolve_server_url", return_value="https://dest.example.com")
+    @patch(
+        "cometx.cli.migrate_users._resolve_server_url",
+        return_value="https://dest.example.com",
+    )
     @patch("cometx.cli.migrate_users._fetch_chargeback_report")
     @patch("builtins.print")
     def test_dry_run_no_api_calls(self, mock_print, mock_fetch, mock_resolve):
@@ -168,7 +186,10 @@ class TestMigrateUsersDryRun:
             migrate_users(self._make_args())
             mock_post.assert_not_called()
 
-    @patch("cometx.cli.migrate_users._resolve_server_url", return_value="https://dest.example.com")
+    @patch(
+        "cometx.cli.migrate_users._resolve_server_url",
+        return_value="https://dest.example.com",
+    )
     @patch("cometx.cli.migrate_users._fetch_chargeback_report")
     @patch("builtins.print")
     def test_dry_run_prints_per_user(self, mock_print, mock_fetch, mock_resolve):
@@ -187,7 +208,10 @@ class TestMigrateUsersDryRun:
         assert "alice@example.com" in printed
         assert "ws1" in printed
 
-    @patch("cometx.cli.migrate_users._resolve_server_url", return_value="https://dest.example.com")
+    @patch(
+        "cometx.cli.migrate_users._resolve_server_url",
+        return_value="https://dest.example.com",
+    )
     @patch("cometx.cli.migrate_users._fetch_chargeback_report")
     @patch("builtins.print")
     def test_dry_run_skips_no_email(self, mock_print, mock_fetch, mock_resolve):
@@ -210,6 +234,21 @@ class TestMigrateUsersDryRun:
         args = self._make_args(source_api_key=None, chargeback_report=None)
         with pytest.raises(SystemExit):
             migrate_users(args)
+
+    @patch(
+        "cometx.cli.migrate_users._resolve_server_url",
+        return_value="comet.example.com",  # no scheme -> admin_api_url raises
+    )
+    @patch("builtins.print")
+    def test_malformed_source_url_exits_cleanly(self, mock_print, mock_resolve):
+        # A source_url without a scheme (e.g. from an API key's embedded
+        # baseUrl, which isn't validated up front) makes admin_api_url raise
+        # ValueError. That must surface as a clean [ERROR] + exit(1), not an
+        # uncaught traceback.
+        with pytest.raises(SystemExit):
+            migrate_users(self._make_args())
+        printed = " ".join(str(c) for c in mock_print.call_args_list)
+        assert "Invalid source server URL" in printed
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_migrate_users.py
+++ b/tests/unit/test_migrate_users.py
@@ -15,7 +15,7 @@ import argparse
 import base64
 import json
 import unittest
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -249,6 +249,25 @@ class TestMigrateUsersDryRun:
             migrate_users(self._make_args())
         printed = " ".join(str(c) for c in mock_print.call_args_list)
         assert "Invalid source server URL" in printed
+
+    @patch(
+        "cometx.cli.migrate_users._resolve_server_url",
+        return_value="https://comet.example.com",
+    )
+    @patch("cometx.cli.migrate_users._fetch_chargeback_report")
+    @patch("builtins.print")
+    def test_non_json_response_is_not_reported_as_a_bad_url(
+        self, mock_print, mock_fetch, mock_resolve
+    ):
+        # response.json() raises json.JSONDecodeError (a ValueError subclass)
+        # when the endpoint answers 2xx with an HTML login page. That must not
+        # be misreported as a malformed source URL.
+        mock_fetch.side_effect = json.JSONDecodeError("Expecting value", "<html>", 0)
+        with pytest.raises(SystemExit):
+            migrate_users(self._make_args())
+        printed = " ".join(str(c) for c in mock_print.call_args_list)
+        assert "did not return JSON" in printed
+        assert "Invalid source server URL" not in printed
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_utils_chargeback.py
+++ b/tests/unit/test_utils_chargeback.py
@@ -39,17 +39,52 @@ def test_fetch_chargeback_appends_report_month():
     assert api._client.get.call_args.kwargs["params"] == {"reportMonth": "2026-06"}
 
 
+def test_fetch_chargeback_allows_http_on_prem_base():
+    # On-prem Comet servers are reached over plain http (documented in
+    # MIGRATIONS.md / README.md); http must not be rejected.
+    from cometx.utils import fetch_chargeback_report
+
+    api = MagicMock()
+    api.config = {"comet.url_override": "http://comet.internal.corp"}
+    api.api_key = "KEY"
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = {}
+    api._client.get.return_value = resp
+
+    fetch_chargeback_report(api)
+
+    called_url = api._client.get.call_args[0][0]
+    assert called_url == "http://comet.internal.corp/api/admin/chargeback/report"
+
+
+def test_fetch_chargeback_preserves_path_prefix():
+    # A base with a path prefix (e.g. /clientlib) must keep that prefix
+    # rather than silently dropping it.
+    from cometx.utils import fetch_chargeback_report
+
+    api = MagicMock()
+    api.config = {"comet.url_override": "https://comet.x.com/clientlib/"}
+    api.api_key = "KEY"
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = {}
+    api._client.get.return_value = resp
+
+    fetch_chargeback_report(api)
+
+    called_url = api._client.get.call_args[0][0]
+    assert called_url == ("https://comet.x.com/clientlib/api/admin/chargeback/report")
+
+
 @pytest.mark.parametrize(
     "base",
     [
-        "http://comet.example.com",  # not https
-        "ftp://comet.example.com",  # wrong scheme
+        "ftp://comet.example.com",  # non-http(s) scheme
         "comet.example.com",  # no scheme/netloc
         "https://",  # empty netloc
         "",  # empty
     ],
 )
-def test_fetch_chargeback_rejects_non_https_base(base):
+def test_fetch_chargeback_rejects_malformed_base(base):
     from cometx.utils import fetch_chargeback_report
 
     api = MagicMock()
@@ -61,7 +96,7 @@ def test_fetch_chargeback_rejects_non_https_base(base):
     api._client.get.assert_not_called()
 
 
-def test_fetch_chargeback_rejects_non_https_host_override():
+def test_fetch_chargeback_rejects_malformed_host_override():
     from cometx.utils import fetch_chargeback_report
 
     api = MagicMock()
@@ -69,5 +104,5 @@ def test_fetch_chargeback_rejects_non_https_host_override():
     api.api_key = "KEY"
 
     with pytest.raises(ValueError):
-        fetch_chargeback_report(api, host="http://127.0.0.1")
+        fetch_chargeback_report(api, host="not-a-url")
     api._client.get.assert_not_called()

--- a/tests/unit/test_utils_chargeback.py
+++ b/tests/unit/test_utils_chargeback.py
@@ -33,10 +33,10 @@ def test_fetch_chargeback_appends_report_month():
     fetch_chargeback_report(api, report_month="2026-06")
 
     called_url = api._client.get.call_args[0][0]
-    assert (
-        called_url
-        == "https://comet.example.com/api/admin/chargeback/report?reportMonth=2026-06"
-    )
+    assert called_url == "https://comet.example.com/api/admin/chargeback/report"
+    # reportMonth is now passed as a query param (URL-encoded by the client),
+    # not interpolated into the URL string.
+    assert api._client.get.call_args.kwargs["params"] == {"reportMonth": "2026-06"}
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_utils_chargeback.py
+++ b/tests/unit/test_utils_chargeback.py
@@ -31,4 +31,7 @@ def test_fetch_chargeback_appends_report_month():
     fetch_chargeback_report(api, report_month="2026-06")
 
     called_url = api._client.get.call_args[0][0]
-    assert called_url == "https://comet.example.com/api/admin/chargeback/report?reportMonth=2026-06"
+    assert (
+        called_url
+        == "https://comet.example.com/api/admin/chargeback/report?reportMonth=2026-06"
+    )

--- a/tests/unit/test_utils_chargeback.py
+++ b/tests/unit/test_utils_chargeback.py
@@ -1,0 +1,34 @@
+from unittest.mock import MagicMock
+
+
+def test_fetch_chargeback_builds_url_and_returns_json():
+    from cometx.utils import fetch_chargeback_report
+
+    api = MagicMock()
+    api.config = {"comet.url_override": "https://comet.example.com/"}
+    api.api_key = "KEY"
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = {"workspaces": [], "users": {}}
+    api._client.get.return_value = resp
+
+    out = fetch_chargeback_report(api)
+
+    assert out == {"workspaces": [], "users": {}}
+    called_url = api._client.get.call_args[0][0]
+    assert called_url == "https://comet.example.com/api/admin/chargeback/report"
+
+
+def test_fetch_chargeback_appends_report_month():
+    from cometx.utils import fetch_chargeback_report
+
+    api = MagicMock()
+    api.config = {"comet.url_override": "https://comet.example.com"}
+    api.api_key = "KEY"
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = {}
+    api._client.get.return_value = resp
+
+    fetch_chargeback_report(api, report_month="2026-06")
+
+    called_url = api._client.get.call_args[0][0]
+    assert called_url == "https://comet.example.com/api/admin/chargeback/report?reportMonth=2026-06"

--- a/tests/unit/test_utils_chargeback.py
+++ b/tests/unit/test_utils_chargeback.py
@@ -85,24 +85,45 @@ def test_fetch_chargeback_preserves_path_prefix():
     ],
 )
 def test_fetch_chargeback_rejects_malformed_base(base):
-    from cometx.utils import fetch_chargeback_report
+    from cometx.utils import InvalidServerURLError, fetch_chargeback_report
 
     api = MagicMock()
     api.config = {"comet.url_override": base}
     api.api_key = "KEY"
 
-    with pytest.raises(ValueError):
+    # A distinct subclass of ValueError so callers can separate a URL problem
+    # from json.JSONDecodeError raised by response.json() (see below).
+    with pytest.raises(InvalidServerURLError):
         fetch_chargeback_report(api)
     api._client.get.assert_not_called()
 
 
+def test_invalid_server_url_error_is_distinct_from_json_decode_error():
+    # Both are ValueErrors, but a non-JSON 2xx body (SSO/proxy login page) is
+    # NOT a URL problem, so `except InvalidServerURLError` must not catch it.
+    import json
+
+    from cometx.utils import InvalidServerURLError, fetch_chargeback_report
+
+    api = MagicMock()
+    api.config = {"comet.url_override": "https://comet.example.com"}
+    api.api_key = "KEY"
+    resp = MagicMock(status_code=200)
+    resp.json.side_effect = json.JSONDecodeError("Expecting value", "<html>", 0)
+    api._client.get.return_value = resp
+
+    assert issubclass(InvalidServerURLError, ValueError)
+    with pytest.raises(json.JSONDecodeError):
+        fetch_chargeback_report(api)
+
+
 def test_fetch_chargeback_rejects_malformed_host_override():
-    from cometx.utils import fetch_chargeback_report
+    from cometx.utils import InvalidServerURLError, fetch_chargeback_report
 
     api = MagicMock()
     api.config = {"comet.url_override": "https://comet.example.com"}
     api.api_key = "KEY"
 
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidServerURLError):
         fetch_chargeback_report(api, host="not-a-url")
     api._client.get.assert_not_called()

--- a/tests/unit/test_utils_chargeback.py
+++ b/tests/unit/test_utils_chargeback.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock
 
+import pytest
+
 
 def test_fetch_chargeback_builds_url_and_returns_json():
     from cometx.utils import fetch_chargeback_report
@@ -35,3 +37,37 @@ def test_fetch_chargeback_appends_report_month():
         called_url
         == "https://comet.example.com/api/admin/chargeback/report?reportMonth=2026-06"
     )
+
+
+@pytest.mark.parametrize(
+    "base",
+    [
+        "http://comet.example.com",  # not https
+        "ftp://comet.example.com",  # wrong scheme
+        "comet.example.com",  # no scheme/netloc
+        "https://",  # empty netloc
+        "",  # empty
+    ],
+)
+def test_fetch_chargeback_rejects_non_https_base(base):
+    from cometx.utils import fetch_chargeback_report
+
+    api = MagicMock()
+    api.config = {"comet.url_override": base}
+    api.api_key = "KEY"
+
+    with pytest.raises(ValueError):
+        fetch_chargeback_report(api)
+    api._client.get.assert_not_called()
+
+
+def test_fetch_chargeback_rejects_non_https_host_override():
+    from cometx.utils import fetch_chargeback_report
+
+    api = MagicMock()
+    api.config = {"comet.url_override": "https://comet.example.com"}
+    api.api_key = "KEY"
+
+    with pytest.raises(ValueError):
+        fetch_chargeback_report(api, host="http://127.0.0.1")
+    api._client.get.assert_not_called()

--- a/tests/unit/test_utils_server_url.py
+++ b/tests/unit/test_utils_server_url.py
@@ -1,0 +1,58 @@
+"""Unit tests for cometx.utils.validate_server_base -- the single shared
+server-URL rule used by --url/--source-url, the migrate-users request
+boundary, and admin_api_url."""
+
+import pytest
+
+from cometx.utils import InvalidServerURLError, validate_server_base
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://comet.example.com",
+        "http://comet.internal.corp",  # on-prem plain http
+        "https://comet.x.com/clientlib/",  # path prefix
+        "http://localhost:8080",
+    ],
+)
+def test_accepts_http_and_https_with_a_host(url):
+    assert validate_server_base(url).netloc
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "ftp://comet.example.com",  # non-http(s) scheme
+        "comet.example.com",  # no scheme/netloc
+        "https://",  # empty netloc
+        "",  # empty
+    ],
+)
+def test_rejects_malformed(url):
+    with pytest.raises(InvalidServerURLError):
+        validate_server_base(url)
+
+
+def test_label_names_the_offending_input():
+    with pytest.raises(InvalidServerURLError) as exc_info:
+        validate_server_base("nope", label="--url/--source-url")
+    assert "--url/--source-url" in str(exc_info.value)
+
+
+def test_all_three_call_sites_share_the_rule():
+    # The point of the shared validator: one base can't be accepted by one
+    # entry point and rejected by another.
+    from cometx.cli.migrate_users import _RequestsClient, _resolve_server_url
+    from cometx.utils import admin_api_url
+
+    on_prem = "http://comet.internal.corp"
+    assert _resolve_server_url("anykey", on_prem) == on_prem
+    assert admin_api_url(on_prem, "/api/admin/chargeback/report").startswith(on_prem)
+
+    with pytest.raises(InvalidServerURLError):
+        admin_api_url("ftp://x.com", "/api/admin/chargeback/report")
+    with pytest.raises(InvalidServerURLError):
+        _RequestsClient().get("ftp://x.com")
+    with pytest.raises(SystemExit):  # the CLI layer converts it to exit(1)
+        _resolve_server_url("anykey", "ftp://x.com")

--- a/tests/unit/test_utils_server_url.py
+++ b/tests/unit/test_utils_server_url.py
@@ -4,7 +4,48 @@ boundary, and admin_api_url."""
 
 import pytest
 
-from cometx.utils import InvalidServerURLError, validate_server_base
+from cometx.utils import (
+    InvalidServerURLError,
+    redact_url_userinfo,
+    validate_server_base,
+)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # credentials replaced, host/path kept
+        ("https://admin:s3cr3t@comet.internal", "https://***@comet.internal"),
+        ("http://user@host/clientlib", "http://***@host/clientlib"),
+        # quoted mid-string, as SDK/HTTP exceptions do
+        (
+            "failed: GET https://u:p@host/api/x returned 403",
+            "failed: GET https://***@host/api/x returned 403",
+        ),
+        # scheme-less base
+        ("admin:s3cr3t@comet.internal", "***@comet.internal"),
+        # an @ in a path is not credentials
+        ("https://comet.internal/a@b", "https://comet.internal/a@b"),
+        # untouched when there is nothing to redact
+        ("https://comet.internal/api", "https://comet.internal/api"),
+        ("", ""),
+    ],
+)
+def test_redact_url_userinfo(raw, expected):
+    assert redact_url_userinfo(raw) == expected
+
+
+def test_redact_url_userinfo_passes_non_strings_through():
+    assert redact_url_userinfo(None) is None
+
+
+def test_validation_error_redacts_credentials():
+    # The error is printed to the terminal / logs, so it must not echo a
+    # password back from the operator-supplied base.
+    with pytest.raises(InvalidServerURLError) as exc_info:
+        validate_server_base("ftp://admin:s3cr3t@comet.internal")
+    assert "s3cr3t" not in str(exc_info.value)
+    assert "***@comet.internal" in str(exc_info.value)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# User description
## Summary

Adds `cometx admin growth-report`: an org-wide growth & adoption report rendered as a single self-contained HTML page, built **entirely from the admin chargeback report**.

**Requires an admin API key.** The report is derived only from the admin chargeback endpoint; with a non-admin key the command prints a clear error and exits non-zero (no fallback).

### Report sections (all chargeback-derived, org-wide by default)
- **Organization overview** — Total workspaces / Total EM projects / New-in-window (% of base) / Active workspaces %, a workspace platform-mix chart (EM / Opik / both / neither), workspace total-vs-active and added-vs-deleted charts, and a by-workspace table.
- **Users** — Total / Active / Active % / New-in-window KPIs plus active-vs-total, adoption-rate, per-capability, and user-churn charts.
- **Leaderboards** — workspaces by experiments/EM projects (exact) and users by Opik spans / EM activity, top-N and active-aware bottom-N.
- **Personal vs service accounts** — experiments/data/spans split; service accounts from the admin service-accounts API with a labeled regex fallback.

Scope is org-wide by default; pass `WORKSPACE` args to scope down. `--exclude-personal` / `--personal-pattern` drop personal workspaces.

### Note on scope / history
Earlier iterations of this PR also included an **SDK/platform-direct methodology** (per-workspace Opik/EM/MPM collection). That approach was consolidated out so this command follows the chargeback methodology only; the later commits strip the SDK data-extraction and rendering. The net diff is the chargeback-only report — recommend **squash-merge** given the build-then-strip history.

### Testing
- 145 unit tests pass (report, render, users, chargeback utils); black/isort/flake8 clean.
- Verified live: chargeback fetch succeeds with an admin key; hard-error + non-zero exit confirmed with a non-admin key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
admin_("admin"):::modified
generate_growth_report_("generate_growth_report"):::modified
fetch_chargeback_report_("fetch_chargeback_report"):::added
GrowthReporter_("GrowthReporter"):::modified
GrowthReporter_assemble_report_data_("GrowthReporter._assemble_report_data"):::added
fetch_service_accounts_("_fetch_service_accounts"):::added
CHARGEBACK_REPORT_API_("CHARGEBACK_REPORT_API"):::added
SERVICE_ACCOUNTS_API_("SERVICE_ACCOUNTS_API"):::added
admin_ -- "Routes growth-report subcommand to new chargeback-based generator." --> generate_growth_report_
admin_ -- "Uses fetch_chargeback_report to GET and save chargeback JSON." --> fetch_chargeback_report_
generate_growth_report_ -- "Instantiates GrowthReporter with active-window, leaderboards, and personal filters." --> GrowthReporter_
GrowthReporter_ -- "GrowthReporter.build now fetches chargeback, validating server base and URL." --> fetch_chargeback_report_
GrowthReporter_ -- "_assemble_report_data fetches service accounts for personal-vs-service charts." --> GrowthReporter_assemble_report_data_
GrowthReporter_assemble_report_data_ -- "_assemble_report_data fetches service accounts for personal-vs-service charts." --> fetch_service_accounts_
fetch_chargeback_report_ -- "fetch_chargeback_report GETs /api/admin/chargeback/report with Authorization, reportMonth." --> CHARGEBACK_REPORT_API_
CHARGEBACK_REPORT_API_ -- "Consumes returned chargeback JSON payload for downstream parsing." --> fetch_chargeback_report_
fetch_service_accounts_ -- "_fetch_service_accounts GETs /api/admin/service-accounts using Authorization headers." --> SERVICE_ACCOUNTS_API_
SERVICE_ACCOUNTS_API_ -- "Parses service-accounts JSON into name set; returns None on failures." --> fetch_service_accounts_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Rework <code>cometx admin growth-report</code> into a chargeback-only HTML report by teaching <code>GrowthReporter</code> to assemble organization, users, leaderboards, and personal-vs-service sections while <code>admin_growth_render</code> draws the new charts and layout. Centralize admin URL and chargeback fetching in <code>utils</code> and <code>migrate_users</code>, then wire the CLI, docs, and tests around the new admin-key-only flow.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/comet-ml/cometx/26?tool=ast&topic=Chargeback+report>Chargeback report</a>
        </td><td>Build an org-wide chargeback-only growth report with <code>admin_growth_report</code>, <code>admin_growth_users</code>, and <code>admin_growth_render</code>, including org overview, user adoption/churn, leaderboards, and personal-vs-service account splits.<details><summary>Modified files (10)</summary><ul><li>README-ADMIN.md</li>
<li>README.md</li>
<li>cometx/_version.py</li>
<li>cometx/cli/admin.py</li>
<li>cometx/cli/admin_growth_render.py</li>
<li>cometx/cli/admin_growth_report.py</li>
<li>cometx/cli/admin_growth_users.py</li>
<li>tests/unit/test_admin_growth_render.py</li>
<li>tests/unit/test_admin_growth_report.py</li>
<li>tests/unit/test_admin_growth_users.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>doug@comet.com</td><td>Version 3.6.9: chargeb...</td><td>July 30, 2026</td></tr>
<tr><td>leobreedt@gmail.com</td><td>fix(growth-report): im...</td><td>July 28, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/comet-ml/cometx/26?tool=ast&topic=URL+hardening>URL hardening</a>
        </td><td>Centralize admin server URL validation and chargeback fetching so <code>admin</code>, <code>migrate_users</code>, and <code>utils</code> preserve path prefixes, allow on-prem <code>http</code>, and redact credentials in errors.<details><summary>Modified files (6)</summary><ul><li>cometx/cli/admin.py</li>
<li>cometx/cli/migrate_users.py</li>
<li>cometx/utils.py</li>
<li>tests/unit/test_migrate_users.py</li>
<li>tests/unit/test_utils_chargeback.py</li>
<li>tests/unit/test_utils_server_url.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>doug@comet.com</td><td>fix(admin): redact URL...</td><td>July 30, 2026</td></tr>
<tr><td>leobreedt@gmail.com</td><td>fix(migrate-users): ca...</td><td>July 29, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/comet-ml/cometx/26?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>